### PR TITLE
Set RA/EX unique items to drop from BCNMs

### DIFF
--- a/modules/init.txt
+++ b/modules/init.txt
@@ -37,7 +37,22 @@
 # Live example:
 
 custom/commands/
+custom/lua/garrison_placeholder_data.lua
+custom/lua/quest_workarounds.lua
 custom/lua/test_npcs_in_gm_home.lua
-phoenix/cpp/account_vars.cpp
-phoenix/lua/chocobo_account_fatigue.lua
-phoenix/sql/account_vars.sql
+era/lua/era_conquest_costs.lua
+era/lua/cop_signet.lua
+era/lua/missable_mom_the_adventurer.lua
+era/lua/northward.lua
+era/lua/pre_rmt_drops.lua
+era/lua/The_Kuftal_Tour.lua
+era/lua/unlocking_a_myth.lua
+era/sql/2hr_ability_cooldowns.sql
+era/sql/2007_exp_tables.sql
+era/sql/cop_level_restrictions.sql
+era/sql/item_cooldowns.sql
+era/sql/original_absorb_casting_time.sql
+era/sql/pre_2014_skill_ranks.sql
+era/sql/pre_rmt_drops.sql
+era/sql/tier_one_weapon_skills.sql
+phoenix

--- a/modules/phoenix/lua/ra_ex_bcnm.lua
+++ b/modules/phoenix/lua/ra_ex_bcnm.lua
@@ -1,0 +1,47 @@
+-----------------------------------
+-- Replaces Unique Items in BCNM battles with RA/EX versions
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('ra_ex_bcnm')
+
+-- TODO: Bring these item listings upstream to item.lua
+local phxItems = {
+    PEACOCK_AMULET = 15515,
+    SHIKAREE_RING  = 15551,
+    VELOCIOUS_BELT = 15899,
+}
+
+local battlefieldInfo = {
+    { bcnm = xi.battlefield.id.PETRIFYING_PAIR,             pool = 2, from = xi.item.LEAPING_BOOTS,   to = xi.item.BOUNDING_BOOTS  },
+    { bcnm = xi.battlefield.id.BROTHERS_D_AURPHE,           pool = 2, from = xi.item.CROSS_COUNTERS,  to = xi.item.RETALIATORS     },
+    { bcnm = xi.battlefield.id.BROTHERS_D_AURPHE,           pool = 5, from = xi.item.EURYTOS_BOW,     to = xi.item.VALIS_BOW       },
+    { bcnm = xi.battlefield.id.DIVINE_PUNISHERS,            pool = 2, from = xi.item.OCHIUDOS_KOTE,   to = xi.item.OCHIMUSHA_KOTE  },
+    { bcnm = xi.battlefield.id.DIVINE_PUNISHERS,            pool = 2, from = xi.item.FUMA_KYAHAN,     to = xi.item.SARUTOBI_KYAHAN },
+    { bcnm = xi.battlefield.id.UP_IN_ARMS,                  pool = 8, from = xi.item.KRAKEN_CLUB,     to = xi.item.OCTAVE_CLUB     },
+    { bcnm = xi.battlefield.id.DROPPING_LIKE_FLIES,         pool = 4, from = xi.item.EMPEROR_HAIRPIN, to = xi.item.EMPRESS_HAIRPIN },
+    { bcnm = xi.battlefield.id.UNDER_OBSERVATION,           pool = 1, from = xi.item.PEACOCK_CHARM,   to = phxItems.PEACOCK_AMULET },
+    { bcnm = xi.battlefield.id.EARLY_BIRD_CATCHES_THE_WYRM, pool = 4, from = xi.item.SPEED_BELT,      to = phxItems.VELOCIOUS_BELT },
+    { bcnm = xi.battlefield.id.HORNS_OF_WAR,                pool = 4, from = xi.item.HEALING_STAFF,   to = xi.item.DRYAD_STAFF     },
+    { bcnm = xi.battlefield.id.HILLS_ARE_ALIVE,             pool = 4, from = xi.item.STRIDER_BOOTS,   to = xi.item.TROTTER_BOOTS   },
+    { bcnm = xi.battlefield.id.ROYAL_JELLY,                 pool = 2, from = xi.item.ARCHERS_RING,    to = phxItems.SHIKAREE_RING  },
+}
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    -- Override BCNM loot drops with RA/EX loot versions
+    for _, replacement in ipairs(battlefieldInfo) do
+        local battlefield = xi.battlefield.contents[replacement.bcnm]
+        if battlefield and battlefield.loot and battlefield.loot[replacement.pool] then
+            for _, lootEntry in ipairs(battlefield.loot[replacement.pool]) do
+                if lootEntry.itemId == replacement.from then
+                    lootEntry.itemId = replacement.to
+                    break
+                end
+            end
+        end
+    end
+end)
+
+return m


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adjust init for modules to load era relevant modules
- Add in module behavior to adjust BCNM drop tables to drop RA/EX item equivalents

Closes https://github.com/phoenixffxi/phoenix-staff/issues/117