### PR TITLE
[lua, sql, cpp] Initializes Account Vars; Account Based Digging Fatigue

### DIFF
--- a/modules/init.txt
+++ b/modules/init.txt
@@ -38,3 +38,6 @@
 
 custom/commands/
 custom/lua/test_npcs_in_gm_home.lua
+phoenix/cpp/account_vars.cpp
+phoenix/lua/chocobo_account_fatigue.lua
+phoenix/sql/account_vars.sql

--- a/modules/phoenix/cpp/account_vars.cpp
+++ b/modules/phoenix/cpp/account_vars.cpp
@@ -1,0 +1,104 @@
+/************************************************************************
+ * Account Variables Module
+ *
+ * This module extends CLuaBaseEntity with account-wide variable methods
+ * similar to how char_vars work but at the account level instead of character level.
+ *
+ * Methods provided:
+ * - player:getAccountVar(varname) - Get an account variable value
+ * - player:setAccountVar(varname, value, expiry) - Set an account variable (value 0 = delete)
+ ************************************************************************/
+
+#include "common/database.h"
+#include "common/logging.h"
+#include "common/vana_time.h"
+#include "map/entities/charentity.h"
+#include "map/lua/luautils.h"
+#include "map/utils/moduleutils.h"
+
+class AccountVarsModule : public CPPModule
+{
+    void OnInit() override
+    {
+        TracyZoneScoped;
+
+        // Startup cleanup of expired account variables
+        uint32 currentTimestamp = earth_time::timestamp();
+        db::preparedStmt("DELETE FROM account_vars WHERE expiry > 0 AND expiry <= ?", currentTimestamp);
+
+        // Extend CLuaBaseEntity with account variable methods
+        sol::usertype<CLuaBaseEntity> baseEntityType = lua["CBaseEntity"];
+
+        baseEntityType["getAccountVar"] = [](CLuaBaseEntity* PLuaBaseEntity, std::string varname) -> int32
+        {
+            if (auto PChar = dynamic_cast<CCharEntity*>(PLuaBaseEntity->GetBaseEntity()))
+            {
+                uint32 accountId = PChar->accid;
+
+                const auto rset = db::preparedStmt(
+                    "SELECT value, expiry FROM account_vars WHERE accountid = ? AND varname = ? LIMIT 1",
+                    accountId, varname);
+
+                int32  value  = 0;
+                uint32 expiry = 0;
+
+                if (rset && rset->rowsCount() && rset->next())
+                {
+                    value  = rset->get<int32>(0);
+                    expiry = rset->get<uint32>(1);
+
+                    // If expired, delete the variable and return 0
+                    if (expiry > 0 && expiry <= earth_time::timestamp())
+                    {
+                        value = 0;
+                        db::preparedStmt("DELETE FROM account_vars WHERE accountid = ? AND varname = ?", accountId, varname);
+                    }
+                }
+
+                return value;
+            }
+
+            return 0;
+        };
+
+        // Register setAccountVar method: player:setAccountVar(varname, value, expiry)
+        // Notes: Passing a '0' value will delete the variable
+        baseEntityType["setAccountVar"] = [](CLuaBaseEntity* PLuaBaseEntity, std::string varname, int32 value, sol::object const& expiry) -> void
+        {
+            if (auto PChar = dynamic_cast<CCharEntity*>(PLuaBaseEntity->GetBaseEntity()))
+            {
+                uint32 accountId   = PChar->accid;
+                uint32 expiryValue = 0;
+
+                // Handle optional expiry parameter
+                if (expiry.is<uint32>())
+                {
+                    expiryValue = expiry.as<uint32>();
+                }
+
+                // Validate expiry timestamp
+                if (expiryValue > 0 && expiryValue <= earth_time::timestamp())
+                {
+                    ShowWarning(fmt::format("Attempting to set account variable '{}' with an expired time: {}", varname, expiryValue));
+                    return;
+                }
+
+                // If value is 0, delete the variable
+                if (value == 0)
+                {
+                    db::preparedStmt("DELETE FROM account_vars WHERE accountid = ? AND varname = ? LIMIT 1", accountId, varname);
+                }
+                else
+                {
+                    // Insert or update the account variable
+                    db::preparedStmt(
+                        "INSERT INTO account_vars SET accountid = ?, varname = ?, value = ?, expiry = ? "
+                        "ON DUPLICATE KEY UPDATE value = ?, expiry = ?",
+                        accountId, varname, value, expiryValue, value, expiryValue);
+                }
+            }
+        };
+    }
+};
+
+REGISTER_CPP_MODULE(AccountVarsModule);

--- a/modules/phoenix/lua/chocobo_account_fatigue.lua
+++ b/modules/phoenix/lua/chocobo_account_fatigue.lua
@@ -1,0 +1,21 @@
+-----------------------------------
+-- Account-wide Chocobo Digging Fatigue
+-- Overrides the chocobo digging fatigue system to use account-wide tracking
+-- instead of per-character tracking
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('chocobo_account_fatigue')
+
+-- Override the fetchFatigue function to use account variables
+m:addOverride('xi.chocoboDig.fetchFatigue', function(player)
+    return player:getAccountVar('[DIG]DigCount')
+end)
+
+-- Override the updateFatigue function to use account variables
+-- Uses NextJstDay() to match the original behavior for daily resets
+m:addOverride('xi.chocoboDig.updateFatigue', function(player, newValue)
+    player:setAccountVar('[DIG]DigCount', newValue, NextJstDay())
+end)
+
+return m

--- a/modules/phoenix/sql/account_vars.sql
+++ b/modules/phoenix/sql/account_vars.sql
@@ -1,0 +1,16 @@
+--
+-- Account Variables Module
+--
+-- Table structure for table `account_vars`
+-- Similar to char_vars but stores variables at account level
+-- Note: This table preserves existing data during database updates.
+--       The table structure will only be created if it doesn't exist.
+--
+
+CREATE TABLE IF NOT EXISTS `account_vars` (
+  `accountid` int(10) unsigned NOT NULL,
+  `varname` varchar(30) NOT NULL,
+  `value` int(11) NOT NULL,
+  `expiry` int(11) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`accountid`,`varname`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Creates a new SQL table to track account based vars, similarly to charVars. 
- Account_var.cpp module created for expired var cleanup, and creates two new bindings: getAccountVar, setAccountVar
- Module created to convert digging fatigue to account based var instead of char based.
- Closes https://github.com/phoenixffxi/phoenix-staff/issues/115

## Steps to test these changes

- Get on a chocobo, dig an item.
- Check new account_vars table for new entry
- Set expiry time to a more recent time and see that it is cleaned up
