### PR TITLE
[Phoenix] Persist seal timer on logout/zone

### DIFF
--- a/modules/phoenix/cpp/persistent_seal_timers.cpp
+++ b/modules/phoenix/cpp/persistent_seal_timers.cpp
@@ -1,0 +1,86 @@
+/*
+===========================================================================
+
+  Persistent Seal Timers Module
+
+  Phoenix Server custom change: Beastmen seals and Kindred seals cooldown does not reset on zoning.
+
+  Implementation:
+  - Saves active seal LOOT recasts to char_vars on zone-out
+  - Restores them on zone-in
+
+===========================================================================
+*/
+
+#include "common/timer.h"
+#include "map/entities/charentity.h"
+#include "map/recast_container.h"
+#include "map/utils/moduleutils.h"
+#include <ctime>
+#include <fmt/format.h>
+
+class PersistentSealTimersModule : public CPPModule
+{
+public:
+    void OnInit() override
+    {
+    }
+
+    void OnCharZoneOut(CCharEntity* PChar) override
+    {
+        if (!PChar)
+        {
+            return;
+        }
+
+        SaveSealTimer(PChar);
+    }
+
+    void OnCharZoneIn(CCharEntity* PChar) override
+    {
+        if (!PChar)
+        {
+            return;
+        }
+
+        RestoreSealTimer(PChar);
+    }
+
+private:
+    static constexpr uint16 RECAST_SEAL = 1;
+
+    void SaveSealTimer(CCharEntity* PChar)
+    {
+        auto* recast = PChar->PRecastContainer->GetRecast(RECAST_LOOT, RECAST_SEAL);
+        if (recast && recast->RecastTime > 0s)
+        {
+            auto remaining = (recast->TimeStamp + recast->RecastTime) - timer::now();
+
+            if (remaining > 10s)
+            {
+                auto remainingSeconds = std::chrono::duration_cast<std::chrono::seconds>(remaining).count();
+                PChar->setCharVar("SealTimer", static_cast<int32>(remainingSeconds));
+                return;
+            }
+        }
+    }
+
+    void RestoreSealTimer(CCharEntity* PChar)
+    {
+        auto remainingSeconds = PChar->getCharVar("SealTimer");
+
+        if (remainingSeconds > 0)
+        {
+            // Sanity check: seal timer should never exceed 5 minutes (300 seconds)
+            // If it does, it's stale data from before a server restart
+            if (remainingSeconds <= 300)
+            {
+                PChar->PRecastContainer->Add(RECAST_LOOT, RECAST_SEAL, std::chrono::seconds(remainingSeconds));
+            }
+
+            PChar->setCharVar("SealTimer", 0);
+        }
+    }
+};
+
+REGISTER_CPP_MODULE(PersistentSealTimersModule);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Sets a charVar on logout or zone of the current timer of beastmen/kindred seals and reapplies it the value upon zone in.
- Closes https://github.com/phoenixffxi/phoenix-staff/issues/292

## Steps to test these changes

- Kill a mob and see that it drops a seal
- Logout or zone
- See that your char has a var set for the cooldown time of SealTimer
