### PR TITLE
[Phoenix] Power Level Nerf Implementation

### DIFF
--- a/modules/phoenix/lua/powerlevel_nerf.lua
+++ b/modules/phoenix/lua/powerlevel_nerf.lua
@@ -1,0 +1,74 @@
+-----------------------------------
+-- Phoenix Power Leveling Nerf Module
+--
+-- Penalize players tanking mobs for parties they're not in.
+-- Penalty stacks up to 5x (-20% EXP each), resets when mob roams at full HP.
+-----------------------------------
+require('modules/module_utils')
+
+local m = Module:new('powerlevel_nerf')
+
+-- Configuration
+local maxPenalty      = 5
+local penaltyPerStack = 20  -- 20% reduction per stack
+
+-- Applies roam listener to mob to ensure exp penalty resets when mob roams at full HP
+local function applyRoamListener(mob)
+    if mob:getLocalVar('expReduction') > 0 then
+        return
+    end
+
+    mob:addListener('ROAM_TICK', 'POWERLEVEL_NERF_ROAM', function(mobEntity)
+        if mobEntity:getHPP() < 100 then
+            return
+        end
+
+        mobEntity:setLocalVar('expReduction', 0)
+        mobEntity:setMobMod(xi.mobMod.EXP_BONUS, 0)
+        mobEntity:removeListener('POWERLEVEL_NERF_ROAM')
+    end)
+end
+
+m:addOverride('xi.player.onGameIn', function(player, firstLogin, zoning)
+    super(player, firstLogin, zoning)
+
+    player:addListener('ATTACKED', 'POWERLEVEL_NERF_ATTACKED', function(playerEntity, attacker)
+        if not attacker or not attacker:isMob() then
+            return
+        end
+
+        if attacker:isNM() then
+            return
+        end
+
+         -- Don't continue if the mob has no enmity table (not claimed)
+        local enmityList = attacker:getEnmityList()
+        if not enmityList or not next(enmityList) then
+            return
+        end
+
+        -- Mob is claimed - check if player has claim
+        if playerEntity:hasClaim(attacker) then
+            return
+        end
+
+        -- Mob is already at max penalty
+        local currentPenalty = attacker:getLocalVar('expReduction')
+        if currentPenalty >= maxPenalty then
+            return
+        end
+
+        -- Apply roam listener to reset penalty if mob deaggros
+        if currentPenalty == 0 then
+            applyRoamListener(attacker)
+        end
+
+        currentPenalty = currentPenalty + 1
+        attacker:setLocalVar('expReduction', currentPenalty)
+
+        local expReduction = math.floor(-currentPenalty * penaltyPerStack)
+        attacker:setMobMod(xi.mobMod.EXP_BONUS, expReduction)
+    end)
+end)
+
+return m


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Implements a power level nerf module. Logic is as follows:
  - Adds an attacked listener to every player when they zone
  - When a mob attacks a player, it checks if the player has claim on the mob. If not it adds an exp reduction stacking up to 5 times for max exp penalty.
  - Exp penalty drops if mob roams and regens back to 100%
- Closes https://github.com/phoenixffxi/phoenix-staff/issues/220

## Steps to test these changes

- Load up three accounts, put two of them in a party
- Pull a mob in the party and get threat on both chars
- Pull threat with the 3rd char and let it hit that char 1 to 5 times
- Kill the mob
- See that it rewards either no EXP or a reduced amount depending on amount of hits
