### PR TITLE
[lua] [module] Disable AV Spawn

### DIFF
--- a/modules/phoenix/lua/disable_av_spawn.lua
+++ b/modules/phoenix/lua/disable_av_spawn.lua
@@ -1,0 +1,13 @@
+-----------------------------------
+-- Disables the chance for Absolute Virtue to spawn after defeating Jailer of Love
+-- For use while Absolute Virtue code is experimental
+-- phoenix/lua/disable_av_spawn.lua
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('disable_jol_av_spawn')
+
+m:addOverride('xi.zones.AlTaieu.mobs.Jailer_of_Love.onMobDespawn', function(mob)
+end)
+
+return m


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Overrides onMobDespawn in Jailer of Love to remove the chance for Absolute Virtue to spawn upon defeating Jailer of Love.
For use while AV code is experimental. 

## Steps to test these changes

Kill many JoL and see that AV never spawns
