### PR TITLE
[Phoenix] Level Sync Penalty Module

### DIFF
--- a/modules/phoenix/cpp/player_count.cpp
+++ b/modules/phoenix/cpp/player_count.cpp
@@ -1,0 +1,33 @@
+/************************************************************************
+ *
+ * Phoenix Population-Based Level Sync Penalty Module
+ *
+ * This module provides a C++ function to query online player count
+ * and exposes it to Lua for use in the penalty calculation system.
+ *
+ ************************************************************************/
+
+#include "common/database.h"
+#include "map/utils/moduleutils.h"
+
+extern sol::state lua;
+
+class PopulationSyncPenaltyModule : public CPPModule
+{
+public:
+    void OnInit() override
+    {
+        lua.set_function("GetOnlinePlayerCount", []() -> int16
+                         {
+                             auto rset = db::preparedStmt("SELECT COUNT(*) as count FROM accounts_sessions");
+                             if (rset && rset->next())
+                             {
+                                 return rset->get<int16>("count");
+                             }
+
+                             return 0;
+                         });
+    }
+};
+
+REGISTER_CPP_MODULE(PopulationSyncPenaltyModule);

--- a/modules/phoenix/lua/level_sync_penalty.lua
+++ b/modules/phoenix/lua/level_sync_penalty.lua
@@ -1,0 +1,128 @@
+-----------------------------------
+-- Phoenix Level Sync Penalty Module
+-- Applies EXP penalties based on server population and level sync difference
+-----------------------------------
+require('modules/module_utils')
+require('scripts/globals/npc_util')
+-----------------------------------
+-- luacheck: globals GetOnlinePlayerCount
+-----------------------------------
+local m = Module:new('population_level_sync_penalty')
+
+-- Configuration (Launch values to be determined at a later date)
+local graceLevels  = 10 -- No penalty within this many levels of sync target
+local maxPenalty   = 50 -- Maximum penalty percentage
+
+-- Population thresholds and penalty rates
+local penaltyTiers =
+{
+    { threshold = 500,  rate = 0 },  -- Below 500: no penalty
+    { threshold = 1000, rate = 15 }, -- 500-999:   1.5% per level
+    { threshold = 2000, rate = 20 }, -- 1000-1999: 2.0% per level
+    { threshold = 9999, rate = 25 }, -- 2000+:     2.5% per level
+}
+
+local function calculatePenalty(player)
+    if not player then
+        return 0
+    end
+
+    if not player:hasStatusEffect(xi.effect.LEVEL_SYNC) then
+        return 0
+    end
+
+    -- Get player's actual level and current synced level
+    local actualLevel = player:getJobLevel(player:getMainJob())
+    local syncLevel = player:getMainLvl()
+    local levelDiff = actualLevel - syncLevel
+
+    if levelDiff <= graceLevels then
+        return 0
+    end
+
+    local penaltyPerLevel = GetServerVariable('[SyncPenalty]RatePerLevel')
+    if penaltyPerLevel == 0 then
+        return 0
+    end
+
+    -- Calculate total penalty
+    local levelsOver = levelDiff - graceLevels
+    local totalPenalty = (levelsOver * penaltyPerLevel) / 10
+    totalPenalty = math.min(totalPenalty, maxPenalty)
+
+    return math.floor(totalPenalty)
+end
+
+-- Determines and applies the appropriate penalty to level synced player
+local function applyPenalty(player)
+    local penaltyValue = calculatePenalty(player)
+
+    if penaltyValue == 0 then
+        return
+    end
+
+    player:setLocalVar('[SyncPenalty]Amount', penaltyValue)
+    player:delMod(xi.mod.EXP_BONUS, penaltyValue)
+end
+
+local function removePenalty(player)
+    local penaltyAmount = player:getLocalVar('[SyncPenalty]Amount')
+
+    if penaltyAmount > 0 then
+        player:addMod(xi.mod.EXP_BONUS, penaltyAmount)
+        player:setLocalVar('[SyncPenalty]Amount', 0)
+    end
+end
+
+-- Update penalty tiers every Vana'diel day, triggered once in GM Home zone file
+m:addOverride('xi.zones.GM_Home.Zone.onGameDay', function()
+    super()
+
+    local playerCount = GetOnlinePlayerCount()
+    local penaltyPerLevel = 0
+
+    for i = 1, #penaltyTiers do
+        if playerCount < penaltyTiers[i].threshold then
+            penaltyPerLevel = penaltyTiers[i].rate
+            break
+        end
+    end
+
+    SetServerVariable('[SyncPenalty]RatePerLevel', penaltyPerLevel)
+end)
+
+-- When a player with sync levels up, recalculate and apply/remove penalty as needed for all party members
+m:addOverride('xi.player.onPlayerLevelUp', function(player)
+    super(player)
+
+    if
+        player:hasStatusEffect(xi.effect.LEVEL_SYNC) and
+        GetServerVariable('[SyncPenalty]RatePerLevel') ~= 0
+    then
+        local party = player:getParty()
+        for _, member in pairs(party) do
+            removePenalty(member)
+            applyPenalty(member)
+        end
+    end
+end)
+
+-- Apply penalty when level sync effect is gained
+m:addOverride('xi.effects.level_sync.onEffectGain', function(target, effect)
+    super(target, effect)
+
+    if target:getObjType() == xi.objType.PC then
+        applyPenalty(target)
+    end
+end)
+
+-- Remove penalty when level sync effect is lost
+m:addOverride('xi.effects.level_sync.onEffectLose', function(target, effect)
+    super(target, effect)
+
+    if target:getObjType() == xi.objType.PC then
+        removePenalty(target)
+    end
+end)
+
+return m


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Implements a level sync penalty module based on a server wide population check. Once per vana'diel day, it will check the current server population and update a server variable with the current penalty.
- Listeners are applied to players through onGameIn which triggers a penalty check when level sync is applied, and when players level up while level synced.
- The penalty gets the level differential between the level sync effect power and the player's true current level, if it is greater than 11 then a penalty is applied per level above 11 based on the current server penalty.
- Closes https://github.com/phoenixffxi/phoenix-staff/issues/224

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
