### PR TITLE
feat(login): launch-token

### DIFF
--- a/sql/accounts_login_tokens.sql
+++ b/sql/accounts_login_tokens.sql
@@ -1,0 +1,22 @@
+-- [Phoenix] Launch Token
+-- Single-use, short-TTL game-launch tokens.
+--
+-- Minted by the Phoenix auth service for an already-authenticated session
+-- (Discord or email/password) and consumed once by xi_connect's LOGIN_ATTEMPT
+-- (see src/login/otp_helpers.h validateAndConsumeLaunchToken). Unlike a trust
+-- token (OTP-bypass only), a launch token stands in for BOTH password and OTP at
+-- boot — justified because the Phoenix session already enforced auth (incl. 2FA)
+-- before minting.
+--
+-- Same shape as accounts_trust_tokens; "single use" and the short (~5 min) TTL
+-- are enforced in code (the row is DELETEd on consume; the mint sets `expires`),
+-- not by the schema. Only the SHA-256 hash of the token is stored.
+CREATE TABLE IF NOT EXISTS `accounts_login_tokens` (
+  `token` CHAR(64) NOT NULL,
+  `accid` INT UNSIGNED NOT NULL,
+  `expires` DATETIME NOT NULL,
+  PRIMARY KEY (`token`),
+  INDEX `idx_accid` (`accid`),
+  INDEX `idx_expires` (`expires`),
+  CONSTRAINT `fk_login_accid` FOREIGN KEY (`accid`) REFERENCES `accounts`(`id`) ON DELETE CASCADE
+);

--- a/src/login/auth_session.cpp
+++ b/src/login/auth_session.cpp
@@ -25,6 +25,8 @@
 #include "common/utils.h"
 #include "otp_helpers.h"
 
+#include <tuple> // [Phoenix] Launch Token
+
 #include <bcrypt/BCrypt.hpp>
 
 #include <nlohmann/json.hpp>
@@ -152,6 +154,7 @@ void auth_session::read_func()
     std::string            updated_password    = loginHelpers::jsonGet<std::string>(jsonBuffer, "new_password").value_or("");
     std::string            otp                 = loginHelpers::jsonGet<std::string>(jsonBuffer, "otp").value_or("");
     std::string            trust_token         = loginHelpers::jsonGet<std::string>(jsonBuffer, "trust_token").value_or("");
+    std::string            login_token         = loginHelpers::jsonGet<std::string>(jsonBuffer, "login_token").value_or(""); // [Phoenix] Launch Token
     bool                   trust_this_computer = loginHelpers::jsonGet<bool>(jsonBuffer, "trust_this_computer").value_or(false);
     std::array<uint8_t, 3> version             = loginHelpers::jsonGet<uint8, 3>(jsonBuffer, "version").value_or(std::array<uint8_t, 3>{ 0, 0, 0 });
 
@@ -165,18 +168,24 @@ void auth_session::read_func()
 
     DebugSockets(fmt::format("auth code: {} from {}", code, ipAddress));
 
-    // data checks
-    if (loginHelpers::isStringMalformed(username, 16))
+    // [Phoenix] Launch Token BEGIN
+    // A launch-token login carries no username/password, so skip those checks
+    // when one is present (isStringMalformed rejects empty strings).
+    if (login_token.empty())
     {
-        ShowWarningFmt("login_parse: malformed username from {}", ipAddress);
-        return;
-    }
+        if (loginHelpers::isStringMalformed(username, 16))
+        {
+            ShowWarningFmt("login_parse: malformed username from {}", ipAddress);
+            return;
+        }
 
-    if (loginHelpers::isStringMalformed(password, 32))
-    {
-        ShowWarningFmt("login_parse: malformed password from {}", ipAddress);
-        return;
+        if (loginHelpers::isStringMalformed(password, 32))
+        {
+            ShowWarningFmt("login_parse: malformed password from {}", ipAddress);
+            return;
+        }
     }
+    // [Phoenix] Launch Token END
 
     switch (static_cast<login_cmd>(code))
     {
@@ -189,17 +198,37 @@ void auth_session::read_func()
         {
             DebugSockets(fmt::format("LOGIN_ATTEMPT from {}", ipAddress));
 
-            // Look up and validate account password
-            auto accountInfo = validatePassword(username, password);
-            if (!accountInfo)
+            uint32 accountID = 0;
+            uint32 status    = 0;
+
+            // [Phoenix] Launch Token BEGIN
+            // Single-use token minted by the auth service stands in for both password
+            // and OTP (the session already enforced 2FA at mint), so skip both here.
+            const bool viaLaunchToken = !login_token.empty();
+            if (viaLaunchToken)
             {
-                sendLoginResult(login_result::LOGIN_ERROR);
-                return;
+                auto launchInfo = otpHelpers::validateAndConsumeLaunchToken(login_token);
+                if (!launchInfo)
+                {
+                    sendLoginResult(login_result::LOGIN_ERROR_LAUNCH_TOKEN_INVALID);
+                    return;
+                }
+                std::tie(accountID, status) = *launchInfo;
             }
+            else
+            {
+                // Look up and validate account password
+                auto accountInfo = validatePassword(username, password);
+                if (!accountInfo)
+                {
+                    sendLoginResult(login_result::LOGIN_ERROR);
+                    return;
+                }
+                std::tie(accountID, status) = *accountInfo;
+            }
+            // [Phoenix] Launch Token END
 
-            auto [accountID, status] = *accountInfo;
-
-            // Reject banned/non-normal accounts before processing OTP or trust tokens
+            // Reject banned/non-normal accounts before processing OTP or trust tokens.
             if (!(status & ACCOUNT_STATUS_CODE::NORMAL))
             {
                 // Purge any lingering trust tokens for banned accounts
@@ -213,7 +242,8 @@ void auth_session::read_func()
 
             bool otpVerified = false;
 
-            if (otpHelpers::doesAccountNeedOTP(accountID, "TOTP"))
+            // [Phoenix] Launch Token: `!viaLaunchToken &&` skips OTP (already satisfied at mint).
+            if (!viaLaunchToken && otpHelpers::doesAccountNeedOTP(accountID, "TOTP"))
             {
                 bool trustedByToken = false;
 

--- a/src/login/auth_session.h
+++ b/src/login/auth_session.h
@@ -49,22 +49,23 @@ enum class login_cmd : uint8_t
 /*return result*/
 enum class login_result : uint8_t
 {
-    LOGIN_FAIL                      = 0x00,
-    LOGIN_SUCCESS                   = 0x01,
-    LOGIN_ERROR                     = 0x02,
-    LOGIN_SUCCESS_CREATE            = 0x03,
-    LOGIN_ERROR_CREATE_TAKEN        = 0x04,
-    LOGIN_REQUEST_NEW_PASSWORD      = 0x05, // is this used?
-    LOGIN_SUCCESS_CHANGE_PASSWORD   = 0x06,
-    LOGIN_ERROR_CHANGE_PASSWORD     = 0x07,
-    LOGIN_ERROR_CREATE_DISABLED     = 0x08,
-    LOGIN_ERROR_CREATE              = 0x09,
-    LOGIN_ERROR_ALREADY_LOGGED_IN   = 0x0A,
-    LOGIN_ERROR_VERSION_UNSUPPORTED = 0x0B,
-    LOGIN_SUCCESS_CREATE_TOTP       = 0x10,
-    LOGIN_SUCCESS_VERIFY_TOTP       = 0x11,
-    LOGIN_SUCCESS_REMOVE_TOTP       = 0x12,
-    LOGIN_ERROR_TRUST_TOKEN_INVALID = 0x13,
+    LOGIN_FAIL                       = 0x00,
+    LOGIN_SUCCESS                    = 0x01,
+    LOGIN_ERROR                      = 0x02,
+    LOGIN_SUCCESS_CREATE             = 0x03,
+    LOGIN_ERROR_CREATE_TAKEN         = 0x04,
+    LOGIN_REQUEST_NEW_PASSWORD       = 0x05, // is this used?
+    LOGIN_SUCCESS_CHANGE_PASSWORD    = 0x06,
+    LOGIN_ERROR_CHANGE_PASSWORD      = 0x07,
+    LOGIN_ERROR_CREATE_DISABLED      = 0x08,
+    LOGIN_ERROR_CREATE               = 0x09,
+    LOGIN_ERROR_ALREADY_LOGGED_IN    = 0x0A,
+    LOGIN_ERROR_VERSION_UNSUPPORTED  = 0x0B,
+    LOGIN_SUCCESS_CREATE_TOTP        = 0x10,
+    LOGIN_SUCCESS_VERIFY_TOTP        = 0x11,
+    LOGIN_SUCCESS_REMOVE_TOTP        = 0x12,
+    LOGIN_ERROR_TRUST_TOKEN_INVALID  = 0x13,
+    LOGIN_ERROR_LAUNCH_TOKEN_INVALID = 0x14, // [Phoenix] Launch Token
 };
 
 constexpr std::array<uint8, 3> SupportedXiloaderVersion = { 2, 1, 0 };

--- a/src/login/otp_helpers.h
+++ b/src/login/otp_helpers.h
@@ -354,4 +354,52 @@ inline void removeAllTrustTokens(uint32 accid)
     db::preparedStmt("DELETE FROM accounts_trust_tokens WHERE accid = ?", accid);
 }
 
+// [Phoenix] Launch Token BEGIN
+// Launch tokens: a single-use, short-TTL credential minted by the Phoenix auth
+// service for an already-authenticated session (Discord or email/pw). Unlike a
+// trust token (which only bypasses the OTP second factor), a launch token stands
+// in for BOTH password and OTP at boot — justified because the Phoenix session
+// already enforced auth (incl. 2FA) before minting. Same 64-hex-char format and
+// SHA-256-at-rest hashing as trust tokens; the auth service inserts the hash into
+// accounts_login_tokens and xi_connect consumes it here.
+//
+// Returns (accid, account status) iff the token is valid AND we are the caller
+// that consumed it (single-use: the DELETE must affect exactly one row). The
+// status is returned so the caller can run the normal ban/NORMAL check.
+inline Maybe<std::pair<uint32, uint32>> validateAndConsumeLaunchToken(const std::string& token)
+{
+    if (!isValidTrustTokenFormat(token)) // 64 hex chars — same format as trust tokens
+    {
+        return std::nullopt;
+    }
+
+    const auto hashed = hashTrustToken(token); // SHA-256 hex — same at-rest hashing
+
+    // Resolve accid + account status for a still-valid token.
+    const auto sel = db::preparedStmt(
+        "SELECT lt.accid AS accid, a.status AS status "
+        "FROM accounts_login_tokens lt "
+        "JOIN accounts a ON a.id = lt.accid "
+        "WHERE lt.token = ? AND lt.expires > NOW()",
+        hashed);
+    if (!sel || !sel->next())
+    {
+        return std::nullopt;
+    }
+
+    const uint32 accid  = sel->get<uint32>("accid");
+    const uint32 status = sel->get<uint32>("status");
+
+    // Consume atomically — single-use. Only the caller whose DELETE actually
+    // removes the row (rowsAffected == 1) wins; a concurrent replay removes 0.
+    const auto del = db::preparedStmt("DELETE FROM accounts_login_tokens WHERE token = ? AND expires > NOW()", hashed);
+    if (!del || del->rowsAffected() != 1)
+    {
+        return std::nullopt;
+    }
+
+    return std::make_pair(accid, status);
+}
+// [Phoenix] Launch Token END
+
 } // namespace otpHelpers


### PR DESCRIPTION
Adds an optional single-use `login_token` path to xi_connect's LOGIN_ATTEMPT so the launcher can boot a Discord-login account (no game password): the token stands in for BOTH password and OTP, consumed once via `validateAndConsumeLaunchToken` (atomic DELETE). Backward-compatible — old xiloaders keep using the password path; `login_token` is purely additive (no client-version bump).

Touches only the login server: `sql/accounts_login_tokens.sql` + `src/login/{auth_session.cpp,auth_session.h,otp_helpers.h}`. Rebased onto current `beta` (just the one commit). Pairs with the phoenix-api launch-token mint endpoint and the launcher's mint-at-Play.