### PR TITLE
Add vendor price fixes reverting RMT baseSell nerfs

### DIFF
--- a/modules/phoenix/sql/pre_rmt_basesell_vendor_revert.sql
+++ b/modules/phoenix/sql/pre_rmt_basesell_vendor_revert.sql
@@ -1,0 +1,379 @@
+-----------------------------------
+--  BaseSell Price Reverts (RMT Nerf Revert)
+-- Module to change the vendor prices of items back to their pre-nerf values
+-----------------------------------
+
+-- Cherry Muffin
+UPDATE item_basic SET baseSell = 164 WHERE itemid = 5653;
+
+-- Cherry Muffin +1
+UPDATE item_basic SET baseSell = 389 WHERE itemid = 5654;
+
+-- Coffee Muffin
+UPDATE item_basic SET baseSell = 230 WHERE itemid = 5655;
+
+-- Cracker
+UPDATE item_basic SET baseSell = 20 WHERE itemid = 4167;
+
+-- Twinkle Shower
+UPDATE item_basic SET baseSell = 24 WHERE itemid = 4168;
+
+-- Little Comet
+UPDATE item_basic SET baseSell = 24 WHERE itemid = 4169;
+
+-- Konron Hassen
+UPDATE item_basic SET baseSell = 21 WHERE itemid = 4183;
+
+-- Kongou Inaho
+UPDATE item_basic SET baseSell = 24 WHERE itemid = 4184;
+
+-- Meifu Goma
+UPDATE item_basic SET baseSell = 36 WHERE itemid = 4185;
+
+-- Airborne
+UPDATE item_basic SET baseSell = 76 WHERE itemid = 4186;
+
+-- Popstar
+UPDATE item_basic SET baseSell = 40 WHERE itemid = 4215;
+
+-- Brilliant Snow
+UPDATE item_basic SET baseSell = 17 WHERE itemid = 4216;
+
+-- Sparkling Hand
+UPDATE item_basic SET baseSell = 27 WHERE itemid = 4217;
+
+-- Air Rider
+UPDATE item_basic SET baseSell = 40 WHERE itemid = 4218;
+
+-- Ouka Ranman
+UPDATE item_basic SET baseSell = 26 WHERE itemid = 4256;
+
+-- Papillion
+UPDATE item_basic SET baseSell = 61 WHERE itemid = 4257;
+
+-- Max-potion
+UPDATE item_basic SET baseSell = 14749 WHERE itemid = 4124;
+
+-- Max-potion +1
+UPDATE item_basic SET baseSell = 18436 WHERE itemid = 4125;
+
+-- Max-potion +2
+UPDATE item_basic SET baseSell = 22016 WHERE itemid = 4126;
+
+-- Max-potion +3
+UPDATE item_basic SET baseSell = 29356 WHERE itemid = 4127;
+
+-- Great Boyahda Moss
+UPDATE item_basic SET baseSell = 4024 WHERE itemid = 1264;
+
+-- Wisteria Lumber
+UPDATE item_basic SET baseSell = 6624 WHERE itemid = 1414;
+
+-- Juji Shuriken
+UPDATE item_basic SET baseSell = 82 WHERE itemid = 17302;
+
+-- Manji Shuriken
+UPDATE item_basic SET baseSell = 183 WHERE itemid = 17303;
+
+-- Kabura Arrow
+UPDATE item_basic SET baseSell = 96 WHERE itemid = 17325;
+
+-- Crackler
+UPDATE item_basic SET baseSell = 34 WHERE itemid = 4250;
+
+-- Elshimo Marble
+UPDATE item_basic SET baseSell = 1492 WHERE itemid = 1146;
+
+-- Shoalweed
+UPDATE item_basic SET baseSell = 2686 WHERE itemid = 1148;
+
+-- Desert Venom
+UPDATE item_basic SET baseSell = 499 WHERE itemid = 1209;
+
+-- Lucky Egg
+UPDATE item_basic SET baseSell = 400 WHERE itemid = 4600;
+
+-- Black Ink
+UPDATE item_basic SET baseSell = 298 WHERE itemid = 929;
+
+-- Bugard Skin
+UPDATE item_basic SET baseSell = 448 WHERE itemid = 1640;
+
+-- High-Quality Bugard Skin
+UPDATE item_basic SET baseSell = 1649 WHERE itemid = 1680;
+
+-- Orc Piercer
+UPDATE item_basic SET baseSell = 8369 WHERE itemid = 16867;
+
+-- Yagudo Freezer
+UPDATE item_basic SET baseSell = 5191 WHERE itemid = 17293;
+
+-- Shellbuster
+UPDATE item_basic SET baseSell = 3920 WHERE itemid = 17415;
+
+-- Leech Saliva
+UPDATE item_basic SET baseSell = 349 WHERE itemid = 1979;
+
+-- Bird Blood
+UPDATE item_basic SET baseSell = 333 WHERE itemid = 2014;
+
+-- Beast Blood
+UPDATE item_basic SET baseSell = 545 WHERE itemid = 2015;
+
+-- Holy Water
+UPDATE item_basic SET baseSell = 349 WHERE itemid = 4154;
+
+-- Burdock
+UPDATE item_basic SET baseSell = 729 WHERE itemid = 5651;
+
+-- Walnut
+UPDATE item_basic SET baseSell = 310 WHERE itemid = 5661;
+
+-- Butterpear
+UPDATE item_basic SET baseSell = 497 WHERE itemid = 5908;
+
+-- Steel Scales
+UPDATE item_basic SET baseSell = 1400 WHERE itemid = 676;
+
+-- Iyo Scale
+UPDATE item_basic SET baseSell = 4634 WHERE itemid = 2006;
+
+-- Brass Zaghnal
+UPDATE item_basic SET baseSell = 564 WHERE itemid = 16769;
+
+-- Brass Finger Gauntlets
+UPDATE item_basic SET baseSell = 735 WHERE itemid = 12689;
+
+-- Brass Cuisses
+UPDATE item_basic SET baseSell = 763 WHERE itemid = 12817;
+
+-- Gold Chain
+UPDATE item_basic SET baseSell = 3433 WHERE itemid = 761;
+
+-- Headgear
+UPDATE item_basic SET baseSell = 193 WHERE itemid = 12464;
+
+-- Doublet
+UPDATE item_basic SET baseSell = 548 WHERE itemid = 12592;
+
+-- Kite Shield
+UPDATE item_basic SET baseSell = 1631 WHERE itemid = 12306;
+
+-- Kite Shield +1
+UPDATE item_basic SET baseSell = 1971 WHERE itemid = 12326;
+
+-- Cotton Headband
+UPDATE item_basic SET baseSell = 400 WHERE itemid = 12498;
+
+-- Erudite's Headband
+UPDATE item_basic SET baseSell = 497 WHERE itemid = 12536;
+
+-- Wool Cap
+UPDATE item_basic SET baseSell = 4130 WHERE itemid = 12467;
+
+-- Wool Cap +1
+UPDATE item_basic SET baseSell = 4935 WHERE itemid = 12541;
+
+-- Black Mitts
+UPDATE item_basic SET baseSell = 2720 WHERE itemid = 12739;
+
+-- Leather Bandana
+UPDATE item_basic SET baseSell = 109 WHERE itemid = 12440;
+
+-- Leather Bandana +1
+UPDATE item_basic SET baseSell = 126 WHERE itemid = 12542;
+
+-- Leather Vest
+UPDATE item_basic SET baseSell = 163 WHERE itemid = 12568;
+
+-- Leather Vest +1
+UPDATE item_basic SET baseSell = 241 WHERE itemid = 12599;
+
+-- Studded Trousers
+UPDATE item_basic SET baseSell = 1671 WHERE itemid = 12826;
+
+-- Cuir Trousers
+UPDATE item_basic SET baseSell = 2345 WHERE itemid = 12827;
+
+-- Raptor Trousers
+UPDATE item_basic SET baseSell = 5174 WHERE itemid = 12828;
+
+-- Behemoth Mantle
+UPDATE item_basic SET baseSell = 4030 WHERE itemid = 13591;
+
+-- Fang Necklace
+UPDATE item_basic SET baseSell = 635 WHERE itemid = 13076;
+
+-- Spike Necklace
+UPDATE item_basic SET baseSell = 930 WHERE itemid = 13061;
+
+-- Bone Axe
+UPDATE item_basic SET baseSell = 882 WHERE itemid = 16642;
+
+-- Bone Axe +1
+UPDATE item_basic SET baseSell = 1025 WHERE itemid = 16666;
+
+-- Beetle Ring
+UPDATE item_basic SET baseSell = 645 WHERE itemid = 13457;
+
+-- Beetle Ring +1
+UPDATE item_basic SET baseSell = 820 WHERE itemid = 13501;
+
+-- Beetle Gorget
+UPDATE item_basic SET baseSell = 773 WHERE itemid = 13090;
+
+-- Green Gorget
+UPDATE item_basic SET baseSell = 958 WHERE itemid = 13062;
+
+-- Turtle Shield
+UPDATE item_basic SET baseSell = 1887 WHERE itemid = 12414;
+
+-- Deodorizer
+UPDATE item_basic SET baseSell = 249 WHERE itemid = 4166;
+
+-- Poison Baselard
+UPDATE item_basic SET baseSell = 1106 WHERE itemid = 16458;
+
+-- Sieglinde Putty
+UPDATE item_basic SET baseSell = 914 WHERE itemid = 1886;
+
+-- Poison Baghnakhs
+UPDATE item_basic SET baseSell = 2101 WHERE itemid = 16410;
+
+-- Targe
+UPDATE item_basic SET baseSell = 1711 WHERE itemid = 12300;
+
+-- Shell Powder
+UPDATE item_basic SET baseSell = 348 WHERE itemid = 1883;
+
+-- Altep Ring
+UPDATE item_basic SET baseSell = 2687 WHERE itemid = 14666;
+
+-- Holla Ring
+UPDATE item_basic SET baseSell = 2687 WHERE itemid = 14661;
+
+-- Dem Ring
+UPDATE item_basic SET baseSell = 2687 WHERE itemid = 14662;
+
+-- Mea Ring
+UPDATE item_basic SET baseSell = 2687 WHERE itemid = 14663;
+
+-- Vahzl Ring
+UPDATE item_basic SET baseSell = 2687 WHERE itemid = 14664;
+
+-- Yhoat Ring
+UPDATE item_basic SET baseSell = 2687 WHERE itemid = 14665;
+
+-- Skull Locust
+UPDATE item_basic SET baseSell = 99 WHERE itemid = 1981;
+
+-- King Locust
+UPDATE item_basic SET baseSell = 200 WHERE itemid = 1982;
+
+-- Mushroom Locust
+UPDATE item_basic SET baseSell = 299 WHERE itemid = 1983;
+
+-- Snapping Mole
+UPDATE item_basic SET baseSell = 414 WHERE itemid = 1984;
+
+-- Helmet Mole
+UPDATE item_basic SET baseSell = 699 WHERE itemid = 1985;
+
+-- Carrot Broth
+UPDATE item_basic SET baseSell = 14 WHERE itemid = 17860;
+
+-- Famous Carrot Broth
+UPDATE item_basic SET baseSell = 46 WHERE itemid = 17861;
+
+-- Bug Broth
+UPDATE item_basic SET baseSell = 107 WHERE itemid = 17862;
+
+-- Quadav Bug Broth
+UPDATE item_basic SET baseSell = 231 WHERE itemid = 17863;
+
+-- Herbal Broth
+UPDATE item_basic SET baseSell = 22 WHERE itemid = 17864;
+
+-- Singing Herbal Broth
+UPDATE item_basic SET baseSell = 111 WHERE itemid = 17865;
+
+-- Carrion Broth
+UPDATE item_basic SET baseSell = 107 WHERE itemid = 17866;
+
+-- Cold Carrion Broth
+UPDATE item_basic SET baseSell = 231 WHERE itemid = 17867;
+
+-- Humus
+UPDATE item_basic SET baseSell = 77 WHERE itemid = 17868;
+
+-- Meat Broth
+UPDATE item_basic SET baseSell = 77 WHERE itemid = 17870;
+
+-- Warm Meat Broth
+UPDATE item_basic SET baseSell = 215 WHERE itemid = 17871;
+
+-- Tree Sap
+UPDATE item_basic SET baseSell = 137 WHERE itemid = 17872;
+
+-- Fish Broth
+UPDATE item_basic SET baseSell = 29 WHERE itemid = 17876;
+
+-- Fish Oil Broth
+UPDATE item_basic SET baseSell = 109 WHERE itemid = 17877;
+
+-- Seedbed Soil
+UPDATE item_basic SET baseSell = 105 WHERE itemid = 17880;
+
+-- Alchemist Water
+UPDATE item_basic SET baseSell = 341 WHERE itemid = 17882;
+
+-- Sun Water
+UPDATE item_basic SET baseSell = 1324 WHERE itemid = 17884;
+
+-- Grasshopper Broth
+UPDATE item_basic SET baseSell = 167 WHERE itemid = 17885;
+
+-- Noisy Grasshopper Broth
+UPDATE item_basic SET baseSell = 308 WHERE itemid = 17886;
+
+-- Mole Broth
+UPDATE item_basic SET baseSell = 412 WHERE itemid = 17887;
+
+-- Blood Broth
+UPDATE item_basic SET baseSell = 351 WHERE itemid = 17889;
+
+-- Clear Blood Broth
+UPDATE item_basic SET baseSell = 450 WHERE itemid = 17890;
+
+-- Antica Broth
+UPDATE item_basic SET baseSell = 306 WHERE itemid = 17891;
+
+-- Fragrant Antica Broth
+UPDATE item_basic SET baseSell = 499 WHERE itemid = 17892;
+
+----------------------------------------------------------------------------------------------------------------------------
+-- PENDING -- I could not find prices for these items, but they were mentioned in patch notes as having price values changed
+----------------------------------------------------------------------------------------------------------------------------
+-- Brass Zaghnal +1
+-- Silver Belt
+-- Silver Belt +1
+-- Brass Finger Gauntlets +1
+-- Brass Cuisses +1
+-- Headgear +1
+-- Doublet +1
+-- Bracers
+-- Bracers +1
+-- Mages Mitts
+-- Strong Trousers
+-- Dino Trousers
+-- Battle Boots
+-- Battle Boots +1
+-- Behemoth Mantle +1
+-- Turtle Shield +1
+-- Hushed Baghnakhs
+-- Python Baselard
+-- Poison Baghnakhs +1
+-- Targe +1
+-- Rich Humus
+-- Scarlet Sap
+-- Lively Mole Broth


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Changes the BaseSell value of items back to the original values before they were nerfed by SE because of RMT.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!additem yagudo_freezer 
see that vendors for 5191 in Al Zahbi 
<!-- Clear and detailed steps to test your changes here -->
