### PR TITLE
fix(login): grant Satchel by 2FA enrollment, not per-login OTP entry

### DIFF
--- a/src/login/auth_session.cpp
+++ b/src/login/auth_session.cpp
@@ -242,8 +242,13 @@ void auth_session::read_func()
 
             bool otpVerified = false;
 
+            // Whether this account has 2FA enabled at all, independent of whether an OTP
+            // code was entered *this* request (see otpVerified below). Used for account-wide
+            // perks like the Satchel grant so they apply regardless of login path.
+            const bool has2FAEnabled = otpHelpers::doesAccountNeedOTP(accountID, "TOTP");
+
             // [Phoenix] Launch Token: `!viaLaunchToken &&` skips OTP (already satisfied at mint).
-            if (!viaLaunchToken && otpHelpers::doesAccountNeedOTP(accountID, "TOTP"))
+            if (!viaLaunchToken && has2FAEnabled)
             {
                 bool trustedByToken = false;
 
@@ -281,9 +286,9 @@ void auth_session::read_func()
 
             dealerChannel_.send(zmq::message_t(payload.data(), payload.size()));
 
-            // set Satchel to the same size as inventory on all chars on their account if character has OTP
+            // set Satchel to the same size as inventory on all chars on their account if the account has 2FA enabled
             // Note: Upgrades happen in-game with gobbiebag
-            if (otpVerified)
+            if (has2FAEnabled)
             {
                 db::preparedStmt("UPDATE char_storage a JOIN char_storage b ON a.charid = b.charid "
                                  "SET a.satchel = b.inventory "


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the Contributing Guide and Code of Conduct.
- [x] I have tested my code and the things my code has changed since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes BUG-0149 ("Satchel not available with 2FA active").

The Satchel size-up (`char_storage.satchel = char_storage.inventory`) at `LOGIN_ATTEMPT` in `src/login/auth_session.cpp` was keyed on `otpVerified`, which only ever gets set `true` on the password+OTP login path. The launch-token path (what the Tauri launcher uses for Discord/web-session logins, minting a single-use token so the client never has to enter a password or OTP) resolves the account without touching that branch, so `otpVerified` stayed `false` even for accounts that genuinely have 2FA on. Since the launcher's the default login method now, satchel basically never granted for anyone using it.

Fix: added `has2FAEnabled`, computed once right after the ban/NORMAL check via the existing `otpHelpers::doesAccountNeedOTP`, independent of `viaLaunchToken`. Satchel grant now keys off that instead of `otpVerified`. Left `otpVerified` and the `trust_this_computer && otpVerified` trust-token block alone since that's a different thing entirely (an OTP actually being entered this request) gating different behavior (trust token issuance), didn't want to conflate the two.

## Steps to test these changes

Rebuilt `xi_connect` from this branch on `phoenix-cli`'s local stack and sent real `LOGIN_ATTEMPT` packets straight to the auth port (54231) against seeded test accounts/characters:

1. Launch token + 2FA enabled: logs in fine, `char_storage.satchel` goes from 0 to 30 (matches inventory), token gets consumed. No `LOGIN_ERROR` or `LOGIN_ERROR_TRUST_TOKEN_INVALID`, which confirms the trust-token/OTP block (still gated by `!viaLaunchToken`, unchanged from before this PR) correctly gets skipped here.
2. Password + OTP + `trust_this_computer=true` (regression check): still logs in fine, still mints a real trust token, satchel still gets granted. Trust-token stuff is untouched.
3. Launch token on an account with no 2FA (regression check): logs in fine, satchel stays untouched like it should.

More detail in the [comment below](https://github.com/phoenixffxi/Phoenix/pull/116#issuecomment-4948739383).