### PR TITLE
Add missing RMT vendor price nerfs

### DIFF
--- a/modules/phoenix/sql/pre_rmt_basesell_vendor_revert.sql
+++ b/modules/phoenix/sql/pre_rmt_basesell_vendor_revert.sql
@@ -351,6 +351,14 @@ UPDATE item_basic SET baseSell = 306 WHERE itemid = 17891;
 -- Fragrant Antica Broth
 UPDATE item_basic SET baseSell = 499 WHERE itemid = 17892;
 
+-- Crab Sushi 
+UPDATE item_basic SET baseSell = 518 WHERE itemid = 5721;
+
+-- Crab Sushi +1
+UPDATE item_basic SET baseSell = 811 WHERE itemid = 5722;
+
+-- Remedy
+UPDATE item_basic SET baseSell = 3200 WHERE itemid = 4155;
 ----------------------------------------------------------------------------------------------------------------------------
 -- PENDING -- I could not find prices for these items, but they were mentioned in patch notes as having price values changed
 ----------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
# Conflicts:
#	modules/phoenix/sql/pre_rmt_basesell_vendor_revert.sql

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds Crab Sushi, Crab Sushi +1 and Remedy vendor nerf reverts
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Sell a remedy to a vendor for 3200 gil.
<!-- Clear and detailed steps to test your changes here -->
