### PR TITLE
[sql] Module to wipe out OOE inventory default values

### DIFF
--- a/modules/custom/sql/disable_optional_storage.sql
+++ b/modules/custom/sql/disable_optional_storage.sql
@@ -1,0 +1,13 @@
+-----------------------------------
+-- Disable Optional Storage
+-- Defaults new players to zerod out wardrobe and case storage
+-----------------------------------
+ALTER TABLE `char_storage` ALTER COLUMN `case`      SET DEFAULT 0;
+ALTER TABLE `char_storage` ALTER COLUMN `wardrobe`  SET DEFAULT 0;
+ALTER TABLE `char_storage` ALTER COLUMN `wardrobe2` SET DEFAULT 0;
+ALTER TABLE `char_storage` ALTER COLUMN `wardrobe3` SET DEFAULT 0;
+ALTER TABLE `char_storage` ALTER COLUMN `wardrobe4` SET DEFAULT 0;
+ALTER TABLE `char_storage` ALTER COLUMN `wardrobe5` SET DEFAULT 0;
+ALTER TABLE `char_storage` ALTER COLUMN `wardrobe6` SET DEFAULT 0;
+ALTER TABLE `char_storage` ALTER COLUMN `wardrobe7` SET DEFAULT 0;
+ALTER TABLE `char_storage` ALTER COLUMN `wardrobe8` SET DEFAULT 0;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds a new module to wipe out default values for several OOE inventory sources.
- Placed in the custom folder now until launch so we don't wipe out new character's inventories during the beta.