### PR TITLE
Enable GM command auditing by default

### DIFF
--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -262,7 +262,7 @@ xi.settings.map =
 
     -- Command Audit [logging] commands with lower permission than this will not be logged.
     -- Zero for no logging at all. Commands given to non GMs are not logged.
-    AUDIT_GM_CMD = false,
+    AUDIT_GM_CMD = 1,
 
     -- Todo = other logging including anti-cheat messages
 


### PR DESCRIPTION
## Summary
- enable LandSandBoat GM command auditing for GM1+ commands
- populate the existing audit_gm table for the admin audit viewer

## Testing
- git diff --check