### PR TITLE
feat(economy): add semantic gil telemetry module

### DIFF
--- a/modules/init.txt
+++ b/modules/init.txt
@@ -54,6 +54,7 @@ wotg/
 # Phoenix modules
 phoenix/cpp
 phoenix/lua
+phoenix/economy
 
 # Dynamis
 phoenix/dynamis/cpp/

--- a/modules/phoenix/economy/CMakeLists.txt
+++ b/modules/phoenix/economy/CMakeLists.txt
@@ -1,0 +1,157 @@
+set(PHOENIX_ECONOMY_RUNTIME_SOURCES
+    "${CMAKE_CURRENT_LIST_DIR}/cpp/economy_correlator.h"
+    "${CMAKE_CURRENT_LIST_DIR}/cpp/economy_event.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/cpp/economy_event.h"
+    "${CMAKE_CURRENT_LIST_DIR}/cpp/economy_module.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/cpp/economy_producer.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/cpp/economy_producer.h"
+)
+
+# modules/init.txt includes this file after xi_map exists. Keeping the source
+# list explicit prevents the standalone .cc harness from entering xi_map.
+if(TARGET xi_map)
+    target_sources(xi_map PRIVATE ${PHOENIX_ECONOMY_RUNTIME_SOURCES})
+    target_include_directories(xi_map PRIVATE "${CMAKE_CURRENT_LIST_DIR}/cpp")
+
+    option(PHOENIX_ECONOMY_BUILD_TESTS "Build the Phoenix economy module harness" OFF)
+    if(PHOENIX_ECONOMY_BUILD_TESTS)
+        include(CTest)
+        find_package(Python3 REQUIRED COMPONENTS Interpreter)
+        add_executable(economy_producer_harness EXCLUDE_FROM_ALL
+            "${CMAKE_CURRENT_LIST_DIR}/cpp/economy_event.cpp"
+            "${CMAKE_CURRENT_LIST_DIR}/cpp/economy_producer.cpp"
+            "${CMAKE_CURRENT_LIST_DIR}/tests/economy_producer_harness.cc"
+        )
+        target_compile_features(economy_producer_harness PRIVATE cxx_std_23)
+        target_compile_definitions(economy_producer_harness PRIVATE PHOENIX_ECONOMY_TESTING=1)
+        target_include_directories(economy_producer_harness PRIVATE
+            "${CMAKE_CURRENT_LIST_DIR}/cpp"
+            "${CMAKE_SOURCE_DIR}/ext/concurrentqueue/concurrentqueue"
+        )
+        target_link_libraries(economy_producer_harness PRIVATE
+            Threads::Threads
+            ZLIB::ZLIB
+            ${OpenSSLlibcrypto_LIBRARY}
+            project_options
+            project_warnings
+        )
+        add_executable(economy_correlator_harness EXCLUDE_FROM_ALL
+            "${CMAKE_CURRENT_LIST_DIR}/tests/economy_correlator_harness.cc"
+        )
+        target_compile_features(economy_correlator_harness PRIVATE cxx_std_23)
+        target_include_directories(economy_correlator_harness PRIVATE "${CMAKE_CURRENT_LIST_DIR}/cpp")
+        target_link_libraries(economy_correlator_harness PRIVATE project_options project_warnings)
+        add_test(
+            NAME economy_spool_contract
+            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/tests/test_spool_contract.py"
+                    --harness "$<TARGET_FILE:economy_producer_harness>"
+        )
+        add_test(NAME economy_correlator_contract COMMAND economy_correlator_harness)
+
+        find_program(PHOENIX_LUAJIT_EXECUTABLE NAMES luajit)
+        if(PHOENIX_LUAJIT_EXECUTABLE)
+            add_test(
+                NAME economy_lua_override_contract
+                COMMAND "${PHOENIX_LUAJIT_EXECUTABLE}"
+                        "${CMAKE_CURRENT_LIST_DIR}/tests/test_lua_overrides.luatest"
+                        "${CMAKE_CURRENT_LIST_DIR}/lua/economy_telemetry.lua"
+            )
+            set_tests_properties(economy_lua_override_contract PROPERTIES
+                ENVIRONMENT "PHOENIX_ECONOMY_TELEMETRY_ENABLED=true"
+            )
+        endif()
+    endif()
+    return()
+endif()
+
+# Standalone producer test project. This path exercises production sources
+# without configuring or linking the full game server.
+cmake_minimum_required(VERSION 3.20)
+project(phoenix_economy_producer_tests LANGUAGES C CXX)
+
+include(CTest)
+include(FetchContent)
+find_package(Threads REQUIRED)
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+get_filename_component(PHOENIX_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
+
+if(WIN32 AND EXISTS "${PHOENIX_ROOT}/ext/openssl/lib64/libcrypto.lib")
+    add_library(phoenix_test_crypto STATIC IMPORTED)
+    set_target_properties(phoenix_test_crypto PROPERTIES
+        IMPORTED_LOCATION "${PHOENIX_ROOT}/ext/openssl/lib64/libcrypto.lib"
+        INTERFACE_INCLUDE_DIRECTORIES "${PHOENIX_ROOT}/ext/openssl/include"
+    )
+else()
+    find_package(OpenSSL REQUIRED COMPONENTS Crypto)
+    add_library(phoenix_test_crypto ALIAS OpenSSL::Crypto)
+endif()
+
+find_package(ZLIB QUIET)
+if(NOT TARGET ZLIB::ZLIB)
+    set(ZLIB_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+    FetchContent_Declare(
+        economy_test_zlib
+        GIT_REPOSITORY https://github.com/madler/zlib.git
+        GIT_TAG v1.3.1
+        GIT_SHALLOW TRUE
+    )
+    FetchContent_MakeAvailable(economy_test_zlib)
+    if(TARGET zlibstatic)
+        add_library(ZLIB::ZLIB ALIAS zlibstatic)
+    else()
+        add_library(ZLIB::ZLIB ALIAS zlib)
+    endif()
+endif()
+
+add_executable(economy_producer_harness
+    cpp/economy_event.cpp
+    cpp/economy_producer.cpp
+    tests/economy_producer_harness.cc
+)
+add_executable(economy_correlator_harness
+    tests/economy_correlator_harness.cc
+)
+target_compile_features(economy_producer_harness PRIVATE cxx_std_23)
+target_compile_features(economy_correlator_harness PRIVATE cxx_std_23)
+target_compile_definitions(economy_producer_harness PRIVATE PHOENIX_ECONOMY_TESTING=1)
+target_include_directories(economy_producer_harness PRIVATE
+    "${CMAKE_CURRENT_LIST_DIR}/cpp"
+    "${PHOENIX_ROOT}/ext/concurrentqueue/concurrentqueue"
+)
+target_include_directories(economy_correlator_harness PRIVATE
+    "${CMAKE_CURRENT_LIST_DIR}/cpp"
+)
+target_link_libraries(economy_producer_harness PRIVATE
+    Threads::Threads
+    ZLIB::ZLIB
+    phoenix_test_crypto
+)
+if(MSVC)
+    target_compile_definitions(economy_producer_harness PRIVATE _CRT_SECURE_NO_WARNINGS)
+    target_compile_options(economy_producer_harness PRIVATE /W4 /WX /permissive- /wd4554)
+    target_compile_options(economy_correlator_harness PRIVATE /W4 /WX /permissive-)
+else()
+    target_compile_options(economy_producer_harness PRIVATE -Wall -Wextra -Werror)
+    target_compile_options(economy_correlator_harness PRIVATE -Wall -Wextra -Werror)
+endif()
+
+add_test(
+    NAME economy_spool_contract
+    COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/tests/test_spool_contract.py"
+            --harness "$<TARGET_FILE:economy_producer_harness>"
+)
+add_test(NAME economy_correlator_contract COMMAND economy_correlator_harness)
+
+find_program(PHOENIX_LUAJIT_EXECUTABLE NAMES luajit)
+if(PHOENIX_LUAJIT_EXECUTABLE)
+    add_test(
+        NAME economy_lua_override_contract
+        COMMAND "${PHOENIX_LUAJIT_EXECUTABLE}"
+                "${CMAKE_CURRENT_LIST_DIR}/tests/test_lua_overrides.luatest"
+                "${CMAKE_CURRENT_LIST_DIR}/lua/economy_telemetry.lua"
+    )
+    set_tests_properties(economy_lua_override_contract PROPERTIES
+        ENVIRONMENT "PHOENIX_ECONOMY_TELEMETRY_ENABLED=true"
+    )
+endif()

--- a/modules/phoenix/economy/README.md
+++ b/modules/phoenix/economy/README.md
@@ -1,0 +1,103 @@
+# Phoenix economy telemetry module
+
+This directory is the independently enabled game-side semantic gil module. Runtime code, Lua
+overrides, producer tests, and build wiring stay under `modules/phoenix/economy`; no LandSandBoat
+core or script file is patched. The module performs no HTTP, network, or database work.
+
+Telemetry is disabled unless explicitly configured. The compiled C++ packet callbacks still incur
+their atomic `enabled()` guard while disabled, but no queue, worker thread, spool directory, Lua
+override, serialization, or I/O is activated.
+
+## Data flow
+
+`Producer::start()` preallocates the moodycamel queue and registers its sole explicit producer token
+before gameplay begins. `Producer::tryRecord()` copies a fixed-size, trivially-copyable accounting
+event or diagnostic through tokenized `try_enqueue`, which cannot allocate. All producer calls come
+from the same map/game thread; an off-thread record is rejected and reported as a sequence gap. The
+hot path does not validate strings, serialize JSON, wait for a lock, or perform I/O. A dedicated
+worker validates and sequences records, emits schema-v2 canonical JSON, computes SHA-256,
+gzip-compresses at most 500 combined records per batch (and at most 100 of either control type), and
+durably completes spool files with temp-file, file flush/fsync, atomic rename, and directory fsync
+where supported.
+
+Accounting events carry `semantic` or `correlated` quality plus an evidence version. Unproven wallet
+deltas become `attributionGaps`; clipped requested rewards become `forgoneMints`. Both are bounded,
+non-accounting controls and never enter mint, burn, or transfer totals.
+
+Startup seeds the first game-thread timestamp, after which the map thread publishes only an atomic
+game-tick timestamp/sequence. The worker flushes records within five seconds and writes a quiet
+heartbeat within 30 seconds only after observing a newer game tick, so a stalled game loop cannot
+manufacture continuing progress. Watermarks cover the latest durable game tick, event, or gap rather
+than worker wall-clock time. `Producer::stop()` writes a final watermark.
+Filenames begin with the fixed-width boot-start Unix time so the forwarder's lexical scan preserves
+chronology across process boots.
+
+Queue overflow, invalid internal events, spool write failure, and spool capacity loss increment the
+cumulative dropped counter and are reported through reserved control-only batches. Normal events
+and quiet heartbeats cannot consume the configured control reserve. Failed persistence attempts are
+rate-limited to one per second; gameplay continues without waiting.
+
+## Configuration
+
+All configuration is read once at module initialization. The producer is off for an unset or false
+enable value. The only case-insensitive true values are `1`, `true`, `yes`, and `on`.
+
+| Environment variable | Required when enabled | Default |
+|---|---:|---:|
+| `PHOENIX_ECONOMY_TELEMETRY_ENABLED` | yes | disabled |
+| `PHOENIX_ECONOMY_PRODUCER_ID` | yes | none |
+| `PHOENIX_ECONOMY_CONTENT_VERSION` | yes | none |
+| `PHOENIX_ECONOMY_SPOOL_DIRECTORY` | yes | none |
+| `PHOENIX_ECONOMY_PRODUCER_VERSION` | no | `phoenix-economy-module-0.1.0` |
+| `PHOENIX_ECONOMY_QUEUE_CAPACITY` | no | `8192` |
+| `PHOENIX_ECONOMY_SPOOL_HARD_CAP_BYTES` | no | `268435456` |
+| `PHOENIX_ECONOMY_SPOOL_CONTROL_RESERVE_BYTES` | no | `1048576` |
+| `PHOENIX_ECONOMY_FLUSH_INTERVAL_MS` | no | `5000` |
+| `PHOENIX_ECONOMY_HEARTBEAT_INTERVAL_MS` | no | `30000` |
+
+Enabling with missing or invalid required values fails closed. No repository setting or production
+configuration enables this module.
+
+Every xi_map producer must have a different `PHOENIX_ECONOMY_SPOOL_DIRECTORY`. Queue ownership,
+hard-cap accounting, temporary names, and the reserved control allowance are process-local; sharing
+one directory would introduce cross-process capacity races and is unsupported. Beta rollout should
+use a stable directory containing the producer/map-port identity and grant the local forwarder read,
+delete, and directory traversal access.
+
+The spool consumer must accept `.json.gz`, reject decompressed payloads above 1 MiB, process files
+in lexical order, and delete a completed file only after the API durably acknowledges it.
+
+Payloads contain numeric character/content IDs and bounded safe-token evidence only, never character
+or NPC display names. Treat the spool as internal operational data: keep it outside a served path,
+use least-privilege host permissions, and give API credentials only to the separate forwarder.
+
+## Instrumentation API
+
+Instrumentation calls `globalProducer().nextTransactionId(prefix)`, fills an `Event` (including
+`occurredAtUnixNanos = unixNanosNow()`), and calls `tryRecord`. An empty event content version is
+replaced by the configured version before enqueue. Overloads accept `AttributionGap` and
+`ForgoneMint`; event and control sequences are worker-assigned. The worker validates actor direction,
+category/source compatibility, typed context, canonical source key, evidence, and numeric bounds.
+Invalid internal records are dropped with a `sequence_discontinuity` gap rather than reaching the
+spool.
+
+The module owner must call `startFromEnvironment()` during initialization and `stop()` during normal
+shutdown. A crash intentionally omits the final watermark so the API can report an ungraceful boot
+transition.
+
+## Standalone contract and hot-path test
+
+The module CMake file explicitly adds only runtime sources to xi_map. It is also a standalone test
+project; the `.cc` harness invokes the production implementation and independently checks canonical
+SHA-256, gzip/decompressed limits, event/control bounds, UINT32 forgone-mint diagnostics, atomic
+completion, hard-cap control reserve, queue overflow, capacity/write-failure gaps, cumulative drops,
+final watermarks, and enqueue p50/p95/p99.
+
+```sh
+cmake -S modules/phoenix/economy -B build/economy-producer-tests
+cmake --build build/economy-producer-tests --config Release
+ctest --test-dir build/economy-producer-tests -C Release --output-on-failure
+```
+
+The producer must remain disabled until the schema-v2 ingest contract is deployed and a beta-only
+forwarder/credential has been provisioned.

--- a/modules/phoenix/economy/cpp/economy_correlator.h
+++ b/modules/phoenix/economy/cpp/economy_correlator.h
@@ -1,0 +1,202 @@
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+namespace phoenix::economy::correlator
+{
+
+enum class Status : std::uint8_t
+{
+    NoChange,
+    Complete,
+    Gap,
+};
+
+enum class Direction : std::uint8_t
+{
+    Credit,
+    Debit,
+};
+
+struct ContextDepth
+{
+    std::size_t  depth{};
+    std::uint8_t suppressionDepth{};
+};
+
+enum class ContextBegin : std::uint8_t
+{
+    Pushed,
+    Suppressed,
+    Rejected,
+};
+
+enum class ContextEnd : std::uint8_t
+{
+    Popped,
+    Unsuppressed,
+    Empty,
+};
+
+[[nodiscard]] constexpr auto beginContext(ContextDepth& state,
+                                          std::size_t   capacity,
+                                          bool          parsedValid) noexcept -> ContextBegin
+{
+    if (state.suppressionDepth > 0 || state.depth >= capacity || !parsedValid)
+    {
+        if (state.suppressionDepth == std::numeric_limits<std::uint8_t>::max())
+        {
+            return ContextBegin::Rejected;
+        }
+        ++state.suppressionDepth;
+        return ContextBegin::Suppressed;
+    }
+
+    ++state.depth;
+    return ContextBegin::Pushed;
+}
+
+[[nodiscard]] constexpr auto endContext(ContextDepth& state) noexcept -> ContextEnd
+{
+    if (state.suppressionDepth > 0)
+    {
+        --state.suppressionDepth;
+        return ContextEnd::Unsuppressed;
+    }
+    if (state.depth > 0)
+    {
+        --state.depth;
+        return ContextEnd::Popped;
+    }
+    return ContextEnd::Empty;
+}
+
+[[nodiscard]] constexpr auto semanticContextUsable(const ContextDepth& state) noexcept -> bool
+{
+    return state.suppressionDepth == 0 && state.depth > 0;
+}
+
+struct SingleResult
+{
+    Status        status{ Status::Gap };
+    std::uint64_t amount{};
+};
+
+[[nodiscard]] constexpr auto reconcileSingle(std::uint64_t before,
+                                             std::uint64_t after,
+                                             Direction     expectedDirection) noexcept -> SingleResult
+{
+    if (before == after)
+    {
+        return { Status::NoChange, 0 };
+    }
+
+    const auto credit = after > before;
+    if ((expectedDirection == Direction::Credit) != credit)
+    {
+        return { Status::Gap, credit ? after - before : before - after };
+    }
+    return { Status::Complete, credit ? after - before : before - after };
+}
+
+struct BazaarResult
+{
+    Status        status{ Status::Gap };
+    std::uint64_t transfer{};
+    std::uint64_t tax{};
+    std::uint64_t capLoss{};
+};
+
+[[nodiscard]] constexpr auto reconcileBazaar(std::uint64_t buyerBefore,
+                                             std::uint64_t buyerAfter,
+                                             std::uint64_t sellerBefore,
+                                             std::uint64_t sellerAfter,
+                                             std::uint64_t baseAmount) noexcept -> BazaarResult
+{
+    if (baseAmount == 0 || buyerAfter > buyerBefore || sellerAfter < sellerBefore)
+    {
+        return {};
+    }
+
+    const auto buyerDebit = buyerBefore - buyerAfter;
+    const auto sellerGain = sellerAfter - sellerBefore;
+    if (buyerDebit < baseAmount || sellerGain > baseAmount)
+    {
+        return {};
+    }
+
+    return {
+        Status::Complete,
+        sellerGain,
+        buyerDebit - baseAmount,
+        baseAmount - sellerGain,
+    };
+}
+
+struct TradeResult
+{
+    Status        status{ Status::Gap };
+    std::uint64_t firstToSecond{};
+    std::uint64_t secondToFirst{};
+    std::uint64_t firstCapLoss{};
+    std::uint64_t secondCapLoss{};
+};
+
+[[nodiscard]] constexpr auto reconcileTrade(std::uint64_t firstBefore,
+                                            std::uint64_t firstAfter,
+                                            std::uint64_t secondBefore,
+                                            std::uint64_t secondAfter,
+                                            std::uint64_t firstOffer,
+                                            std::uint64_t secondOffer) noexcept -> TradeResult
+{
+    if (firstOffer == 0 && secondOffer == 0)
+    {
+        return { Status::NoChange };
+    }
+
+    const auto firstCreditSigned  = static_cast<std::int64_t>(firstAfter) -
+                                    static_cast<std::int64_t>(firstBefore) +
+                                    static_cast<std::int64_t>(firstOffer);
+    const auto secondCreditSigned = static_cast<std::int64_t>(secondAfter) -
+                                    static_cast<std::int64_t>(secondBefore) +
+                                    static_cast<std::int64_t>(secondOffer);
+    if (firstCreditSigned < 0 || secondCreditSigned < 0 ||
+        firstCreditSigned > static_cast<std::int64_t>(secondOffer) ||
+        secondCreditSigned > static_cast<std::int64_t>(firstOffer))
+    {
+        return {};
+    }
+
+    const auto secondToFirst = static_cast<std::uint64_t>(firstCreditSigned);
+    const auto firstToSecond = static_cast<std::uint64_t>(secondCreditSigned);
+    return {
+        Status::Complete,
+        firstToSecond,
+        secondToFirst,
+        firstOffer - firstToSecond,
+        secondOffer - secondToFirst,
+    };
+}
+
+[[nodiscard]] constexpr auto expiryStatus(bool          walletObserved,
+                                          std::uint64_t before,
+                                          std::uint64_t latest) noexcept -> Status
+{
+    return walletObserved && before != latest ? Status::Gap : Status::NoChange;
+}
+
+struct MintClip
+{
+    std::uint64_t applied{};
+    std::uint64_t forgone{};
+};
+
+[[nodiscard]] constexpr auto reconcileMint(std::uint64_t requested, std::uint64_t applied) noexcept -> MintClip
+{
+    return { applied, requested > applied ? requested - applied : 0 };
+}
+
+} // namespace phoenix::economy::correlator

--- a/modules/phoenix/economy/cpp/economy_event.cpp
+++ b/modules/phoenix/economy/cpp/economy_event.cpp
@@ -1,0 +1,338 @@
+#include "economy_event.h"
+
+#include <algorithm>
+#include <chrono>
+#include <limits>
+
+namespace phoenix::economy
+{
+namespace
+{
+
+template <std::size_t Capacity>
+auto appendToken(FixedString<Capacity>& output, std::string_view token) noexcept -> bool
+{
+    if (output.length + token.size() > Capacity)
+    {
+        return false;
+    }
+
+    std::memcpy(output.bytes.data() + output.length, token.data(), token.size());
+    output.length               = static_cast<std::uint16_t>(output.length + token.size());
+    output.bytes[output.length] = '\0';
+    return true;
+}
+
+template <std::size_t Capacity, typename T>
+auto appendNumber(FixedString<Capacity>& output, T value) noexcept -> bool
+{
+    auto* const begin  = output.bytes.data() + output.length;
+    auto* const end    = output.bytes.data() + Capacity;
+    const auto  result = std::to_chars(begin, end, value);
+    if (result.ec != std::errc{})
+    {
+        return false;
+    }
+
+    output.length               = static_cast<std::uint16_t>(result.ptr - output.bytes.data());
+    output.bytes[output.length] = '\0';
+    return true;
+}
+
+auto canonicalSourceKey(const Event& event, SourceKey& output) noexcept -> bool
+{
+    output.clear();
+    const auto colon = [&output]()
+    {
+        return appendToken(output, ":");
+    };
+
+    switch (event.sourceType)
+    {
+        case SourceType::Mob:
+            return appendToken(output, "mob") && colon() && appendNumber(output, event.context.mobSpawnId.value);
+        case SourceType::Npc:
+            return appendToken(output, "npc") && colon() && appendNumber(output, event.zoneId.value) && colon() &&
+                   appendNumber(output, event.context.npcId.value);
+        case SourceType::Quest:
+            return appendToken(output, "quest") && colon() && appendNumber(output, event.context.questLogId.value) && colon() &&
+                   appendNumber(output, event.context.questId.value);
+        case SourceType::Mission:
+            return appendToken(output, "mission") && colon() && appendNumber(output, event.context.missionLogId.value) && colon() &&
+                   appendNumber(output, event.context.missionId.value);
+        case SourceType::Battlefield:
+            return appendToken(output, "battlefield") && colon() && appendNumber(output, event.context.battlefieldId.value);
+        case SourceType::Regime:
+            return appendToken(output, "regime") && colon() && appendNumber(output, event.context.regimeId.value);
+        case SourceType::Admin:
+            return appendToken(output, "admin") && colon() && appendNumber(output, event.context.actorCharId.value);
+        case SourceType::Script:
+            return appendToken(output, "script") && colon() && appendToken(output, event.context.scriptKey.view());
+        case SourceType::System:
+            return appendToken(output, "system") && colon() && appendToken(output, event.context.systemKey.view());
+    }
+
+    return false;
+}
+
+auto categoryAcceptsSource(Category category, SourceType sourceType) noexcept -> bool
+{
+    switch (category)
+    {
+        case Category::MobDrop:
+        case Category::Mug:
+            return sourceType == SourceType::Mob;
+        case Category::NpcVendorSale:
+        case Category::GuildVendorSale:
+        case Category::NpcShopPurchase:
+        case Category::GuildShopPurchase:
+            return sourceType == SourceType::Npc;
+        case Category::QuestReward:
+            return sourceType == SourceType::Quest;
+        case Category::MissionReward:
+            return sourceType == SourceType::Mission;
+        case Category::BattlefieldReward:
+            return sourceType == SourceType::Battlefield;
+        case Category::RegimeReward:
+            return sourceType == SourceType::Regime;
+        case Category::StartingGil:
+            return sourceType == SourceType::System;
+        case Category::AdminGrant:
+        case Category::AdminRemove:
+            return sourceType == SourceType::Admin;
+        case Category::ScriptReward:
+            return sourceType == SourceType::Script || sourceType == SourceType::Npc || sourceType == SourceType::System;
+        case Category::OtherMint:
+        case Category::OtherBurn:
+            return sourceType == SourceType::Script || sourceType == SourceType::System || sourceType == SourceType::Npc;
+        case Category::ChocoboRental:
+        case Category::TransportFee:
+        case Category::ServiceFee:
+            return sourceType == SourceType::Npc || sourceType == SourceType::System;
+        case Category::QuestFee:
+            return sourceType == SourceType::Quest || sourceType == SourceType::Mission || sourceType == SourceType::Npc ||
+                   sourceType == SourceType::System;
+        case Category::AuctionListingFee:
+        case Category::BazaarTax:
+        case Category::CurrencyCapLoss:
+        case Category::PlayerTrade:
+        case Category::BazaarSale:
+        case Category::AuctionSale:
+        case Category::DeliveryBox:
+        case Category::OtherTransfer:
+            return sourceType == SourceType::System;
+    }
+    return false;
+}
+
+auto hasOnlyMobContext(const SourceContext& context) noexcept -> bool
+{
+    return !context.npcId.hasValue && !context.shopId.hasValue && !context.guildId.hasValue &&
+           !context.questLogId.hasValue && !context.questId.hasValue && !context.missionLogId.hasValue &&
+           !context.missionId.hasValue && !context.battlefieldId.hasValue && !context.regimeId.hasValue &&
+           !context.actorCharId.hasValue && context.serviceKey.empty() && context.scriptKey.empty() && context.systemKey.empty();
+}
+
+auto hasOnlyNpcContext(const SourceContext& context) noexcept -> bool
+{
+    return !context.mobSpawnId.hasValue && !context.mobPoolId.hasValue && !context.questLogId.hasValue &&
+           !context.questId.hasValue && !context.missionLogId.hasValue && !context.missionId.hasValue &&
+           !context.battlefieldId.hasValue && !context.regimeId.hasValue && !context.actorCharId.hasValue &&
+           context.scriptKey.empty() && context.systemKey.empty();
+}
+
+auto hasOnlyQuestContext(const SourceContext& context) noexcept -> bool
+{
+    return !context.mobSpawnId.hasValue && !context.mobPoolId.hasValue && !context.npcId.hasValue &&
+           !context.shopId.hasValue && !context.guildId.hasValue && !context.missionLogId.hasValue &&
+           !context.missionId.hasValue && !context.battlefieldId.hasValue && !context.regimeId.hasValue &&
+           !context.actorCharId.hasValue && context.serviceKey.empty() && context.scriptKey.empty() && context.systemKey.empty();
+}
+
+auto hasOnlyMissionContext(const SourceContext& context) noexcept -> bool
+{
+    return !context.mobSpawnId.hasValue && !context.mobPoolId.hasValue && !context.npcId.hasValue &&
+           !context.shopId.hasValue && !context.guildId.hasValue && !context.questLogId.hasValue &&
+           !context.questId.hasValue && !context.battlefieldId.hasValue && !context.regimeId.hasValue &&
+           !context.actorCharId.hasValue && context.serviceKey.empty() && context.scriptKey.empty() && context.systemKey.empty();
+}
+
+auto hasOnlySingleNumericContext(const SourceContext& context, SourceType sourceType) noexcept -> bool
+{
+    const auto battlefieldAllowed = sourceType == SourceType::Battlefield;
+    const auto regimeAllowed      = sourceType == SourceType::Regime;
+    const auto adminAllowed       = sourceType == SourceType::Admin;
+    return !context.mobSpawnId.hasValue && !context.mobPoolId.hasValue && !context.npcId.hasValue &&
+           !context.shopId.hasValue && !context.guildId.hasValue && !context.questLogId.hasValue &&
+           !context.questId.hasValue && !context.missionLogId.hasValue && !context.missionId.hasValue &&
+           (battlefieldAllowed || !context.battlefieldId.hasValue) && (regimeAllowed || !context.regimeId.hasValue) &&
+           (adminAllowed || !context.actorCharId.hasValue) && context.serviceKey.empty() && context.scriptKey.empty() &&
+           context.systemKey.empty();
+}
+
+auto hasOnlyScriptContext(const SourceContext& context) noexcept -> bool
+{
+    return !context.mobSpawnId.hasValue && !context.mobPoolId.hasValue && !context.npcId.hasValue &&
+           !context.shopId.hasValue && !context.guildId.hasValue && !context.questLogId.hasValue &&
+           !context.questId.hasValue && !context.missionLogId.hasValue && !context.missionId.hasValue &&
+           !context.battlefieldId.hasValue && !context.regimeId.hasValue && !context.actorCharId.hasValue &&
+           context.serviceKey.empty() && context.systemKey.empty();
+}
+
+auto hasOnlySystemContext(const SourceContext& context) noexcept -> bool
+{
+    return !context.mobSpawnId.hasValue && !context.mobPoolId.hasValue && !context.npcId.hasValue &&
+           !context.shopId.hasValue && !context.guildId.hasValue && !context.questLogId.hasValue &&
+           !context.questId.hasValue && !context.missionLogId.hasValue && !context.missionId.hasValue &&
+           !context.battlefieldId.hasValue && !context.regimeId.hasValue && !context.actorCharId.hasValue &&
+           context.serviceKey.empty() && context.scriptKey.empty();
+}
+
+} // namespace
+
+auto isSafeToken(std::string_view value) noexcept -> bool
+{
+    if (value.empty())
+    {
+        return false;
+    }
+
+    for (const auto character : value)
+    {
+        const auto alphaNumeric = (character >= 'A' && character <= 'Z') || (character >= 'a' && character <= 'z') ||
+                                  (character >= '0' && character <= '9');
+        if (!alphaNumeric && character != '.' && character != '_' && character != ':' && character != '+' &&
+            character != '/' && character != '-')
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+auto isValidEvent(const Event& event) noexcept -> bool
+{
+    constexpr auto MaxFutureSkewNanos = 5LL * 60LL * 1000000000LL;
+    if (event.occurredAtUnixNanos <= 0 || event.amount == 0 || event.amount > MaxGilAmount ||
+        event.occurredAtUnixNanos > unixNanosNow() + MaxFutureSkewNanos ||
+        event.kind != kindForCategory(event.category) || !isSafeToken(event.transactionId.view()) ||
+        !categoryAcceptsSource(event.category, event.sourceType) ||
+        !isSafeToken(event.contentVersion.view()) || !isSafeToken(event.sourceKey.view()) ||
+        !isSafeToken(event.evidenceVersion.view()) ||
+        event.attributionQuality > AttributionQuality::Correlated ||
+        !isPositiveCharacterId(event.fromCharId) || !isPositiveCharacterId(event.toCharId) ||
+        (event.itemQuantity.hasValue && event.itemQuantity.value == 0))
+    {
+        return false;
+    }
+
+    switch (event.kind)
+    {
+        case Kind::Mint:
+            if (event.fromCharId.hasValue || !event.toCharId.hasValue)
+            {
+                return false;
+            }
+            break;
+        case Kind::Burn:
+            if (!event.fromCharId.hasValue || event.toCharId.hasValue)
+            {
+                return false;
+            }
+            break;
+        case Kind::Transfer:
+            if (!event.fromCharId.hasValue || !event.toCharId.hasValue || event.fromCharId.value == event.toCharId.value)
+            {
+                return false;
+            }
+            break;
+    }
+
+    auto contextValid = false;
+    switch (event.sourceType)
+    {
+        case SourceType::Mob:
+            contextValid = event.context.mobSpawnId.hasValue && event.context.mobSpawnId.value > 0 &&
+                           (!event.context.mobPoolId.hasValue || event.context.mobPoolId.value > 0) && hasOnlyMobContext(event.context);
+            break;
+        case SourceType::Npc:
+            contextValid = event.zoneId.hasValue && event.context.npcId.hasValue && event.context.npcId.value > 0 &&
+                           (event.context.serviceKey.empty() || isSafeToken(event.context.serviceKey.view())) &&
+                           hasOnlyNpcContext(event.context);
+            break;
+        case SourceType::Quest:
+            contextValid = event.context.questLogId.hasValue && event.context.questId.hasValue && hasOnlyQuestContext(event.context);
+            break;
+        case SourceType::Mission:
+            contextValid = event.context.missionLogId.hasValue && event.context.missionId.hasValue && hasOnlyMissionContext(event.context);
+            break;
+        case SourceType::Battlefield:
+            contextValid = event.context.battlefieldId.hasValue && hasOnlySingleNumericContext(event.context, event.sourceType);
+            break;
+        case SourceType::Regime:
+            contextValid = event.context.regimeId.hasValue && hasOnlySingleNumericContext(event.context, event.sourceType);
+            break;
+        case SourceType::Admin:
+            contextValid = event.context.actorCharId.hasValue && event.context.actorCharId.value > 0 &&
+                           hasOnlySingleNumericContext(event.context, event.sourceType);
+            break;
+        case SourceType::Script:
+            contextValid = isSafeToken(event.context.scriptKey.view()) && hasOnlyScriptContext(event.context);
+            break;
+        case SourceType::System:
+            contextValid = isSafeToken(event.context.systemKey.view()) && hasOnlySystemContext(event.context);
+            break;
+    }
+
+    SourceKey expectedSourceKey;
+    return contextValid && canonicalSourceKey(event, expectedSourceKey) && expectedSourceKey.view() == event.sourceKey.view();
+}
+
+auto isValidAttributionGap(const AttributionGap& gap) noexcept -> bool
+{
+    constexpr auto MaxFutureSkewNanos = 5LL * 60LL * 1000000000LL;
+    return gap.occurredAtUnixNanos > 0 && gap.occurredAtUnixNanos <= unixNanosNow() + MaxFutureSkewNanos &&
+           gap.charId > 0 && gap.appliedDelta > 0 && gap.appliedDelta <= MaxGilAmount &&
+           gap.direction <= AttributionDirection::Debit && gap.evidenceType <= EvidenceType::TransferReconciliation &&
+           isSafeToken(gap.evidenceVersion.view()) && isSafeToken(gap.detailCode.view()) &&
+           isSafeToken(gap.contentVersion.view()) && (gap.sourceHint.empty() || isSafeToken(gap.sourceHint.view()));
+}
+
+auto isValidForgoneMint(const ForgoneMint& diagnostic) noexcept -> bool
+{
+    if (diagnostic.requestedAmount == 0 || diagnostic.requestedAmount > std::numeric_limits<std::uint32_t>::max() ||
+        diagnostic.appliedAmount > MaxGilAmount || diagnostic.forgoneAmount == 0 ||
+        diagnostic.forgoneAmount > std::numeric_limits<std::uint32_t>::max() ||
+        diagnostic.appliedAmount >= diagnostic.requestedAmount ||
+        diagnostic.requestedAmount - diagnostic.appliedAmount != diagnostic.forgoneAmount ||
+        kindForCategory(diagnostic.category) != Kind::Mint)
+    {
+        return false;
+    }
+
+    Event sourceValidation;
+    sourceValidation.occurredAtUnixNanos = diagnostic.occurredAtUnixNanos;
+    sourceValidation.transactionId       = diagnostic.transactionId;
+    sourceValidation.kind                = Kind::Mint;
+    sourceValidation.category            = diagnostic.category;
+    // isValidEvent is reused only for category/source/context validation here;
+    // accounting events are wallet-capped, while forgone diagnostics may span uint32.
+    sourceValidation.amount = std::min(diagnostic.forgoneAmount, MaxGilAmount);
+    sourceValidation.toCharId.set(diagnostic.charId);
+    sourceValidation.zoneId             = diagnostic.zoneId;
+    sourceValidation.contentVersion     = diagnostic.contentVersion;
+    sourceValidation.sourceType         = diagnostic.sourceType;
+    sourceValidation.sourceKey          = diagnostic.sourceKey;
+    sourceValidation.context            = diagnostic.context;
+    sourceValidation.attributionQuality = diagnostic.attributionQuality;
+    sourceValidation.evidenceVersion    = diagnostic.evidenceVersion;
+    return isValidEvent(sourceValidation);
+}
+
+auto unixNanosNow() noexcept -> std::int64_t
+{
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+}
+
+} // namespace phoenix::economy

--- a/modules/phoenix/economy/cpp/economy_event.h
+++ b/modules/phoenix/economy/cpp/economy_event.h
@@ -1,0 +1,267 @@
+#pragma once
+
+#include <array>
+#include <charconv>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <string_view>
+#include <type_traits>
+
+namespace phoenix::economy
+{
+
+constexpr std::uint64_t MaxGilAmount = 999999999ULL;
+
+template <std::size_t Capacity>
+struct FixedString
+{
+    static_assert(Capacity > 0);
+
+    std::array<char, Capacity + 1> bytes{};
+    std::uint16_t                  length{};
+
+    [[nodiscard]] auto assign(std::string_view value) noexcept -> bool
+    {
+        if (value.empty() || value.size() > Capacity)
+        {
+            return false;
+        }
+
+        std::memcpy(bytes.data(), value.data(), value.size());
+        length        = static_cast<std::uint16_t>(value.size());
+        bytes[length] = '\0';
+        return true;
+    }
+
+    void clear() noexcept
+    {
+        length   = 0;
+        bytes[0] = '\0';
+    }
+
+    [[nodiscard]] auto view() const noexcept -> std::string_view
+    {
+        return { bytes.data(), length };
+    }
+
+    [[nodiscard]] auto empty() const noexcept -> bool
+    {
+        return length == 0;
+    }
+};
+
+template <typename T>
+struct Nullable
+{
+    T    value{};
+    bool hasValue{};
+
+    constexpr void set(T next) noexcept
+    {
+        value    = next;
+        hasValue = true;
+    }
+
+    constexpr void reset() noexcept
+    {
+        value    = {};
+        hasValue = false;
+    }
+};
+
+using TransactionId   = FixedString<128>;
+using ContentVersion  = FixedString<64>;
+using SourceKey       = FixedString<128>;
+using ServiceKey      = FixedString<64>;
+using ScriptKey       = FixedString<96>;
+using SystemKey       = FixedString<96>;
+using EvidenceVersion = FixedString<64>;
+using DetailCode      = FixedString<64>;
+using SourceHint      = FixedString<128>;
+
+enum class Kind : std::uint8_t
+{
+    Mint,
+    Burn,
+    Transfer,
+};
+
+enum class Category : std::uint8_t
+{
+    MobDrop,
+    Mug,
+    NpcVendorSale,
+    GuildVendorSale,
+    QuestReward,
+    MissionReward,
+    BattlefieldReward,
+    RegimeReward,
+    StartingGil,
+    AdminGrant,
+    ScriptReward,
+    OtherMint,
+    NpcShopPurchase,
+    GuildShopPurchase,
+    AuctionListingFee,
+    BazaarTax,
+    ChocoboRental,
+    TransportFee,
+    QuestFee,
+    ServiceFee,
+    CurrencyCapLoss,
+    AdminRemove,
+    OtherBurn,
+    PlayerTrade,
+    BazaarSale,
+    AuctionSale,
+    DeliveryBox,
+    OtherTransfer,
+};
+
+enum class SourceType : std::uint8_t
+{
+    Mob,
+    Npc,
+    Quest,
+    Mission,
+    Battlefield,
+    Regime,
+    Admin,
+    Script,
+    System,
+};
+
+enum class AttributionQuality : std::uint8_t
+{
+    Semantic,
+    Correlated,
+};
+
+enum class AttributionDirection : std::uint8_t
+{
+    Credit,
+    Debit,
+};
+
+enum class EvidenceType : std::uint8_t
+{
+    LuaWallet,
+    WalletObserver,
+    PacketCorrelator,
+    NativePacket,
+    TransferReconciliation,
+};
+
+// V2 source context. Only the fields allowed for Event::sourceType are emitted.
+// String keys are canonical SAFE_TOKEN values, never display names.
+struct SourceContext
+{
+    Nullable<std::uint32_t> mobSpawnId;
+    Nullable<std::uint32_t> mobPoolId;
+    Nullable<std::uint32_t> npcId;
+    Nullable<std::uint32_t> shopId;
+    Nullable<std::uint16_t> guildId;
+    Nullable<std::uint16_t> questLogId;
+    Nullable<std::uint16_t> questId;
+    Nullable<std::uint16_t> missionLogId;
+    Nullable<std::uint16_t> missionId;
+    Nullable<std::uint16_t> battlefieldId;
+    Nullable<std::uint16_t> regimeId;
+    Nullable<std::uint32_t> actorCharId;
+    ServiceKey              serviceKey;
+    ScriptKey               scriptKey;
+    SystemKey               systemKey;
+};
+
+// Fixed-size, trivially-copyable payload passed from the game thread to the
+// telemetry worker. eventSeq is assigned in dequeue order by the worker.
+struct Event
+{
+    std::uint64_t           eventSeq{};
+    std::int64_t            occurredAtUnixNanos{};
+    TransactionId           transactionId;
+    Kind                    kind{};
+    Category                category{};
+    std::uint64_t           amount{};
+    Nullable<std::uint32_t> fromCharId;
+    Nullable<std::uint32_t> toCharId;
+    Nullable<std::uint16_t> zoneId;
+    Nullable<std::uint16_t> itemId;
+    Nullable<std::uint32_t> itemQuantity;
+    ContentVersion          contentVersion;
+    SourceType              sourceType{};
+    SourceKey               sourceKey;
+    SourceContext           context;
+    AttributionQuality      attributionQuality{ AttributionQuality::Semantic };
+    EvidenceVersion         evidenceVersion;
+};
+
+// Non-accounting diagnostic for an applied wallet delta whose accounting kind
+// or category cannot be proven. It is never included in mint/burn/transfer totals.
+struct AttributionGap
+{
+    std::uint64_t           controlSeq{};
+    std::int64_t            occurredAtUnixNanos{};
+    std::uint32_t           charId{};
+    Nullable<std::uint16_t> zoneId;
+    AttributionDirection    direction{};
+    std::uint64_t           appliedDelta{};
+    EvidenceType            evidenceType{};
+    EvidenceVersion         evidenceVersion;
+    SourceHint              sourceHint;
+    DetailCode              detailCode;
+    ContentVersion          contentVersion;
+};
+
+// Non-accounting diagnostic for a requested mint clipped by the gil cap.
+struct ForgoneMint
+{
+    std::uint64_t           controlSeq{};
+    std::int64_t            occurredAtUnixNanos{};
+    std::uint32_t           charId{};
+    Nullable<std::uint16_t> zoneId;
+    std::uint64_t           requestedAmount{};
+    std::uint64_t           appliedAmount{};
+    std::uint64_t           forgoneAmount{};
+    Category                category{ Category::OtherMint };
+    TransactionId           transactionId;
+    SourceType              sourceType{};
+    SourceKey               sourceKey;
+    SourceContext           context;
+    AttributionQuality      attributionQuality{ AttributionQuality::Semantic };
+    EvidenceVersion         evidenceVersion;
+    ContentVersion          contentVersion;
+};
+
+[[nodiscard]] constexpr auto kindForCategory(Category category) noexcept -> Kind
+{
+    if (category <= Category::OtherMint)
+    {
+        return Kind::Mint;
+    }
+    if (category <= Category::OtherBurn)
+    {
+        return Kind::Burn;
+    }
+    return Kind::Transfer;
+}
+
+[[nodiscard]] constexpr auto isPositiveCharacterId(const Nullable<std::uint32_t>& id) noexcept -> bool
+{
+    return !id.hasValue || id.value > 0;
+}
+
+[[nodiscard]] auto isSafeToken(std::string_view value) noexcept -> bool;
+[[nodiscard]] auto isValidEvent(const Event& event) noexcept -> bool;
+[[nodiscard]] auto isValidAttributionGap(const AttributionGap& gap) noexcept -> bool;
+[[nodiscard]] auto isValidForgoneMint(const ForgoneMint& diagnostic) noexcept -> bool;
+[[nodiscard]] auto unixNanosNow() noexcept -> std::int64_t;
+
+static_assert(std::is_trivially_copyable_v<FixedString<128>>);
+static_assert(std::is_trivially_copyable_v<Event>);
+static_assert(std::is_trivially_copyable_v<AttributionGap>);
+static_assert(std::is_trivially_copyable_v<ForgoneMint>);
+static_assert(sizeof(Event) <= 2048);
+
+} // namespace phoenix::economy

--- a/modules/phoenix/economy/cpp/economy_module.cpp
+++ b/modules/phoenix/economy/cpp/economy_module.cpp
@@ -1,0 +1,2228 @@
+#include "economy_correlator.h"
+#include "economy_event.h"
+#include "economy_producer.h"
+
+#include "common/logging.h"
+#include "map/entities/char_entity.h"
+#include "map/entities/mob_entity.h"
+#include "map/enums/msg_basic.h"
+#include "map/enums/packet_c2s.h"
+#include "map/enums/packet_s2c.h"
+#include "map/item_container.h"
+#include "map/items/item.h"
+#include "map/lua/lua_base_entity.h"
+#include "map/map_session.h"
+#include "map/packets/basic.h"
+#include "map/packets/c2s/0x033_trade_res.h"
+#include "map/packets/c2s/0x04e_auc.h"
+#include "map/packets/c2s/0x083_shop_buy.h"
+#include "map/packets/c2s/0x085_shop_sell_set.h"
+#include "map/packets/c2s/0x106_bazaar_buy.h"
+#include "map/packets/s2c/0x022_item_trade_res.h"
+#include "map/packets/s2c/0x029_battle_message.h"
+#include "map/trade_container.h"
+#include "map/universal_container.h"
+#include "map/utils/moduleutils.h"
+#include "map/zone.h"
+
+#include <algorithm>
+#include <array>
+#include <charconv>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace
+{
+
+using namespace phoenix::economy;
+using SteadyClock = std::chrono::steady_clock;
+
+constexpr std::size_t      MaxTrackedCharacters    = 2048;
+constexpr std::size_t      MaxSemanticContextDepth = 16;
+constexpr std::size_t      MaxPendingPerCharacter  = 4;
+constexpr auto             NativeDeadline          = std::chrono::seconds(5);
+constexpr auto             MobDeadline             = std::chrono::seconds(2);
+constexpr auto             ShopDeadline            = std::chrono::seconds(30);
+constexpr auto             ExpirySweepInterval     = std::chrono::milliseconds(250);
+constexpr std::string_view EvidenceVersionKey      = "phoenix-economy-correlator-v1";
+
+enum class SlotState : std::uint8_t
+{
+    Empty,
+    Occupied,
+    Tombstone,
+};
+
+enum class NativeOperation : std::uint8_t
+{
+    ShopBuy,
+    ShopSell,
+    Bazaar,
+    PlayerTrade,
+    AuctionListing,
+    MobDrop,
+};
+
+enum class PairRole : std::uint8_t
+{
+    First,
+    Second,
+};
+
+struct SemanticContext
+{
+    std::optional<Category> mintCategory;
+    std::optional<Category> burnCategory;
+    SourceType              sourceType{ SourceType::Script };
+    SourceContext           source;
+    Nullable<std::uint16_t> zoneId;
+    Nullable<std::uint16_t> itemId;
+    Nullable<std::uint32_t> itemQuantity;
+    TransactionId           transactionId;
+};
+
+struct ShopContext
+{
+    bool                    active{};
+    SemanticContext         semantic;
+    SteadyClock::time_point deadline{};
+};
+
+struct PendingOperation
+{
+    bool                    active{};
+    NativeOperation         operation{};
+    PairRole                role{ PairRole::First };
+    bool                    walletObserved{};
+    bool                    resultObserved{};
+    bool                    ambiguous{};
+    bool                    gapReported{};
+    std::uint8_t            walletPacketCount{};
+    SteadyClock::time_point deadline{};
+    TransactionId           transactionId;
+    SemanticContext         semantic;
+
+    std::uint32_t firstCharId{};
+    std::uint32_t secondCharId{};
+    std::uint64_t firstBefore{};
+    std::uint64_t secondBefore{};
+    std::uint64_t firstOffer{};
+    std::uint64_t secondOffer{};
+    std::uint64_t expectedBaseAmount{};
+
+    std::uint64_t beforeGil{};
+    std::uint64_t latestGil{};
+};
+
+struct CharacterState
+{
+    SlotState                                            slotState{ SlotState::Empty };
+    std::uint32_t                                        charId{};
+    std::uint16_t                                        zoneId{};
+    bool                                                 walletShadowValid{};
+    std::uint64_t                                        walletShadow{};
+    std::uint8_t                                         luaMutationDepth{};
+    bool                                                 pendingOverflow{};
+    ShopContext                                          shop;
+    std::array<SemanticContext, MaxSemanticContextDepth> contexts{};
+    correlator::ContextDepth                             contextScope;
+    std::array<PendingOperation, MaxPendingPerCharacter> pending{};
+};
+
+class KeyBuilder
+{
+public:
+    auto append(std::string_view value) noexcept -> bool
+    {
+        if (!valid_ || size_ + value.size() > bytes_.size())
+        {
+            valid_ = false;
+            return false;
+        }
+
+        std::copy(value.begin(), value.end(), bytes_.begin() + size_);
+        size_ += value.size();
+        return true;
+    }
+
+    template <typename T>
+    auto appendNumber(T value, int base = 10) noexcept -> bool
+    {
+        if (!valid_)
+        {
+            return false;
+        }
+
+        const auto result = std::to_chars(bytes_.data() + size_, bytes_.data() + bytes_.size(), value, base);
+        if (result.ec != std::errc{})
+        {
+            valid_ = false;
+            return false;
+        }
+
+        size_ = static_cast<std::size_t>(result.ptr - bytes_.data());
+        return true;
+    }
+
+    [[nodiscard]] auto view() const noexcept -> std::string_view
+    {
+        return valid_ ? std::string_view(bytes_.data(), size_) : std::string_view{};
+    }
+
+private:
+    std::array<char, 128> bytes_{};
+    std::size_t           size_{};
+    bool                  valid_{ true };
+};
+
+[[nodiscard]] auto walletGil(const CCharEntity* PChar) noexcept -> std::optional<std::uint64_t>
+{
+    if (!PChar)
+    {
+        return std::nullopt;
+    }
+
+    const auto* inventory = PChar->getStorage(LOC_INVENTORY);
+    const auto* gil       = inventory ? inventory->GetItem(0) : nullptr;
+    if (!gil || !gil->isType(ITEM_CURRENCY))
+    {
+        return std::nullopt;
+    }
+
+    return gil->getQuantity();
+}
+
+[[nodiscard]] auto luaCharacter(CLuaBaseEntity* entity) noexcept -> CCharEntity*
+{
+    return entity ? dynamic_cast<CCharEntity*>(entity->GetBaseEntity()) : nullptr;
+}
+
+[[nodiscard]] auto luaMob(CLuaBaseEntity* entity) noexcept -> CMobEntity*
+{
+    return entity ? dynamic_cast<CMobEntity*>(entity->GetBaseEntity()) : nullptr;
+}
+
+[[nodiscard]] auto categoryFromString(std::string_view value) noexcept -> std::optional<Category>
+{
+    struct Entry
+    {
+        std::string_view key;
+        Category         category;
+    };
+
+    static constexpr std::array entries{
+        Entry{ "mob_drop", Category::MobDrop },
+        Entry{ "mug", Category::Mug },
+        Entry{ "npc_vendor_sale", Category::NpcVendorSale },
+        Entry{ "guild_vendor_sale", Category::GuildVendorSale },
+        Entry{ "quest_reward", Category::QuestReward },
+        Entry{ "mission_reward", Category::MissionReward },
+        Entry{ "battlefield_reward", Category::BattlefieldReward },
+        Entry{ "regime_reward", Category::RegimeReward },
+        Entry{ "starting_gil", Category::StartingGil },
+        Entry{ "admin_grant", Category::AdminGrant },
+        Entry{ "script_reward", Category::ScriptReward },
+        Entry{ "other_mint", Category::OtherMint },
+        Entry{ "npc_shop_purchase", Category::NpcShopPurchase },
+        Entry{ "guild_shop_purchase", Category::GuildShopPurchase },
+        Entry{ "auction_listing_fee", Category::AuctionListingFee },
+        Entry{ "bazaar_tax", Category::BazaarTax },
+        Entry{ "chocobo_rental", Category::ChocoboRental },
+        Entry{ "transport_fee", Category::TransportFee },
+        Entry{ "quest_fee", Category::QuestFee },
+        Entry{ "service_fee", Category::ServiceFee },
+        Entry{ "currency_cap_loss", Category::CurrencyCapLoss },
+        Entry{ "admin_remove", Category::AdminRemove },
+        Entry{ "other_burn", Category::OtherBurn },
+        Entry{ "player_trade", Category::PlayerTrade },
+        Entry{ "bazaar_sale", Category::BazaarSale },
+        Entry{ "auction_sale", Category::AuctionSale },
+        Entry{ "delivery_box", Category::DeliveryBox },
+        Entry{ "other_transfer", Category::OtherTransfer },
+    };
+
+    for (const auto& entry : entries)
+    {
+        if (entry.key == value)
+        {
+            return entry.category;
+        }
+    }
+
+    return std::nullopt;
+}
+
+[[nodiscard]] auto sourceTypeFromString(std::string_view value) noexcept -> std::optional<SourceType>
+{
+    if (value == "mob")
+    {
+        return SourceType::Mob;
+    }
+    if (value == "npc")
+    {
+        return SourceType::Npc;
+    }
+    if (value == "quest")
+    {
+        return SourceType::Quest;
+    }
+    if (value == "mission")
+    {
+        return SourceType::Mission;
+    }
+    if (value == "battlefield")
+    {
+        return SourceType::Battlefield;
+    }
+    if (value == "regime")
+    {
+        return SourceType::Regime;
+    }
+    if (value == "admin")
+    {
+        return SourceType::Admin;
+    }
+    if (value == "script")
+    {
+        return SourceType::Script;
+    }
+    if (value == "system")
+    {
+        return SourceType::System;
+    }
+
+    return std::nullopt;
+}
+
+template <typename T>
+auto readUnsigned(const sol::table& table, const char* key, Nullable<T>& destination) -> bool
+{
+    const sol::object value = table[key];
+    if (!value.valid() || value == sol::lua_nil)
+    {
+        return true;
+    }
+    if (!value.is<std::uint64_t>())
+    {
+        return false;
+    }
+
+    const auto number = value.as<std::uint64_t>();
+    if (number > std::numeric_limits<T>::max())
+    {
+        return false;
+    }
+
+    destination.set(static_cast<T>(number));
+    return true;
+}
+
+template <std::size_t Capacity>
+auto readToken(const sol::table& table, const char* key, FixedString<Capacity>& destination) -> bool
+{
+    const sol::object value = table[key];
+    if (!value.valid() || value == sol::lua_nil)
+    {
+        return true;
+    }
+    if (!value.is<std::string>())
+    {
+        return false;
+    }
+
+    const auto token = value.as<std::string>();
+    return isSafeToken(token) && destination.assign(token);
+}
+
+[[nodiscard]] auto parseSemanticContext(CCharEntity* PChar, const sol::table& table) -> std::optional<SemanticContext>
+{
+    if (!PChar)
+    {
+        return std::nullopt;
+    }
+
+    SemanticContext context;
+    context.zoneId.set(PChar->getZone());
+
+    const auto parseCategory = [&](const char* key, Kind expectedKind, std::optional<Category>& destination) -> bool
+    {
+        const sol::object value = table[key];
+        if (!value.valid() || value == sol::lua_nil)
+        {
+            return true;
+        }
+        if (!value.is<std::string>())
+        {
+            return false;
+        }
+
+        destination = categoryFromString(value.as<std::string>());
+        return destination.has_value() && kindForCategory(*destination) == expectedKind;
+    };
+
+    if (!parseCategory("mintCategory", Kind::Mint, context.mintCategory) ||
+        !parseCategory("burnCategory", Kind::Burn, context.burnCategory))
+    {
+        return std::nullopt;
+    }
+
+    const sol::object sourceType = table["sourceType"];
+    if (!sourceType.valid() || sourceType == sol::lua_nil || !sourceType.is<std::string>())
+    {
+        return std::nullopt;
+    }
+
+    const auto parsedSourceType = sourceTypeFromString(sourceType.as<std::string>());
+    if (!parsedSourceType)
+    {
+        return std::nullopt;
+    }
+    context.sourceType = *parsedSourceType;
+
+    if (!readUnsigned(table, "zoneId", context.zoneId) ||
+        !readUnsigned(table, "itemId", context.itemId) ||
+        !readUnsigned(table, "itemQuantity", context.itemQuantity) ||
+        !readUnsigned(table, "mobSpawnId", context.source.mobSpawnId) ||
+        !readUnsigned(table, "mobPoolId", context.source.mobPoolId) ||
+        !readUnsigned(table, "npcId", context.source.npcId) ||
+        !readUnsigned(table, "shopId", context.source.shopId) ||
+        !readUnsigned(table, "guildId", context.source.guildId) ||
+        !readUnsigned(table, "questLogId", context.source.questLogId) ||
+        !readUnsigned(table, "questId", context.source.questId) ||
+        !readUnsigned(table, "missionLogId", context.source.missionLogId) ||
+        !readUnsigned(table, "missionId", context.source.missionId) ||
+        !readUnsigned(table, "battlefieldId", context.source.battlefieldId) ||
+        !readUnsigned(table, "regimeId", context.source.regimeId) ||
+        !readUnsigned(table, "actorCharId", context.source.actorCharId) ||
+        !readToken(table, "serviceKey", context.source.serviceKey) ||
+        !readToken(table, "scriptKey", context.source.scriptKey) ||
+        !readToken(table, "systemKey", context.source.systemKey))
+    {
+        return std::nullopt;
+    }
+
+    context.transactionId = globalProducer().nextTransactionId("lua");
+    return context;
+}
+
+[[nodiscard]] auto systemContext(std::string_view key) -> SemanticContext
+{
+    SemanticContext context;
+    context.sourceType = SourceType::System;
+    static_cast<void>(context.source.systemKey.assign(key));
+    return context;
+}
+
+auto appendSourceKeyPart(KeyBuilder& builder, std::string_view separator, std::uint64_t value) -> bool
+{
+    return builder.append(separator) && builder.appendNumber(value);
+}
+
+auto populateEventSource(Event& event, const SemanticContext& semantic) -> bool
+{
+    event.sourceType = semantic.sourceType;
+    KeyBuilder key;
+
+    switch (semantic.sourceType)
+    {
+        case SourceType::Mob:
+            if (!semantic.source.mobSpawnId.hasValue || !key.append("mob") ||
+                !appendSourceKeyPart(key, ":", semantic.source.mobSpawnId.value))
+            {
+                return false;
+            }
+            event.context.mobSpawnId = semantic.source.mobSpawnId;
+            event.context.mobPoolId  = semantic.source.mobPoolId;
+            break;
+        case SourceType::Npc:
+            if (!semantic.source.npcId.hasValue || !event.zoneId.hasValue || !key.append("npc") ||
+                !appendSourceKeyPart(key, ":", event.zoneId.value) ||
+                !appendSourceKeyPart(key, ":", semantic.source.npcId.value))
+            {
+                return false;
+            }
+            event.context.npcId      = semantic.source.npcId;
+            event.context.shopId     = semantic.source.shopId;
+            event.context.guildId    = semantic.source.guildId;
+            event.context.serviceKey = semantic.source.serviceKey;
+            break;
+        case SourceType::Quest:
+            if (!semantic.source.questLogId.hasValue || !semantic.source.questId.hasValue || !key.append("quest") ||
+                !appendSourceKeyPart(key, ":", semantic.source.questLogId.value) ||
+                !appendSourceKeyPart(key, ":", semantic.source.questId.value))
+            {
+                return false;
+            }
+            event.context.questLogId = semantic.source.questLogId;
+            event.context.questId    = semantic.source.questId;
+            break;
+        case SourceType::Mission:
+            if (!semantic.source.missionLogId.hasValue || !semantic.source.missionId.hasValue || !key.append("mission") ||
+                !appendSourceKeyPart(key, ":", semantic.source.missionLogId.value) ||
+                !appendSourceKeyPart(key, ":", semantic.source.missionId.value))
+            {
+                return false;
+            }
+            event.context.missionLogId = semantic.source.missionLogId;
+            event.context.missionId    = semantic.source.missionId;
+            break;
+        case SourceType::Battlefield:
+            if (!semantic.source.battlefieldId.hasValue || !key.append("battlefield") ||
+                !appendSourceKeyPart(key, ":", semantic.source.battlefieldId.value))
+            {
+                return false;
+            }
+            event.context.battlefieldId = semantic.source.battlefieldId;
+            break;
+        case SourceType::Regime:
+            if (!semantic.source.regimeId.hasValue || !key.append("regime") ||
+                !appendSourceKeyPart(key, ":", semantic.source.regimeId.value))
+            {
+                return false;
+            }
+            event.context.regimeId = semantic.source.regimeId;
+            break;
+        case SourceType::Admin:
+            if (!semantic.source.actorCharId.hasValue || !key.append("admin") ||
+                !appendSourceKeyPart(key, ":", semantic.source.actorCharId.value))
+            {
+                return false;
+            }
+            event.context.actorCharId = semantic.source.actorCharId;
+            break;
+        case SourceType::Script:
+            if (semantic.source.scriptKey.empty() || !key.append("script:") || !key.append(semantic.source.scriptKey.view()))
+            {
+                return false;
+            }
+            event.context.scriptKey = semantic.source.scriptKey;
+            break;
+        case SourceType::System:
+            if (semantic.source.systemKey.empty() || !key.append("system:") || !key.append(semantic.source.systemKey.view()))
+            {
+                return false;
+            }
+            event.context.systemKey = semantic.source.systemKey;
+            break;
+    }
+
+    return event.sourceKey.assign(key.view());
+}
+
+void recordEvent(Category                     category,
+                 std::uint64_t                amount,
+                 const SemanticContext&       semantic,
+                 const TransactionId&         transactionId,
+                 std::optional<std::uint32_t> fromCharId,
+                 std::optional<std::uint32_t> toCharId,
+                 AttributionQuality           quality)
+{
+    auto& producer = globalProducer();
+    if (!producer.enabled() || amount == 0 || amount > MaxGilAmount)
+    {
+        return;
+    }
+
+    Event event;
+    event.occurredAtUnixNanos = unixNanosNow();
+    event.transactionId       = transactionId;
+    event.kind                = kindForCategory(category);
+    event.category            = category;
+    event.amount              = amount;
+    event.zoneId              = semantic.zoneId;
+    event.itemId              = semantic.itemId;
+    event.itemQuantity        = semantic.itemQuantity;
+    event.attributionQuality  = quality;
+    static_cast<void>(event.evidenceVersion.assign(EvidenceVersionKey));
+
+    if (fromCharId && *fromCharId > 0)
+    {
+        event.fromCharId.set(*fromCharId);
+    }
+    if (toCharId && *toCharId > 0)
+    {
+        event.toCharId.set(*toCharId);
+    }
+
+    if (!populateEventSource(event, semantic))
+    {
+        return;
+    }
+
+    static_cast<void>(producer.tryRecord(event));
+}
+
+void recordGap(std::uint32_t    charId,
+               std::uint16_t    zoneId,
+               std::uint64_t    before,
+               std::uint64_t    after,
+               EvidenceType     evidenceType,
+               std::string_view detailCode,
+               std::string_view sourceHint = {})
+{
+    if (charId == 0 || before == after)
+    {
+        return;
+    }
+
+    AttributionGap gap;
+    gap.occurredAtUnixNanos = unixNanosNow();
+    gap.charId              = charId;
+    gap.zoneId.set(zoneId);
+    gap.direction    = after > before ? AttributionDirection::Credit : AttributionDirection::Debit;
+    gap.appliedDelta = after > before ? after - before : before - after;
+    gap.evidenceType = evidenceType;
+    static_cast<void>(gap.evidenceVersion.assign(EvidenceVersionKey));
+    static_cast<void>(gap.detailCode.assign(detailCode));
+    if (!sourceHint.empty() && isSafeToken(sourceHint) && sourceHint.size() <= gap.sourceHint.bytes.size() - 1)
+    {
+        static_cast<void>(gap.sourceHint.assign(sourceHint));
+    }
+    static_cast<void>(globalProducer().tryRecord(gap));
+}
+
+void recordForgoneMint(Category               category,
+                       std::uint64_t          requested,
+                       std::uint64_t          applied,
+                       std::uint32_t          charId,
+                       const SemanticContext& semantic,
+                       const TransactionId&   transactionId,
+                       AttributionQuality     quality)
+{
+    if (requested == 0 || requested > std::numeric_limits<std::uint32_t>::max() ||
+        applied > MaxGilAmount || applied >= requested)
+    {
+        return;
+    }
+
+    Event sourceEvent;
+    sourceEvent.zoneId = semantic.zoneId;
+    if (!populateEventSource(sourceEvent, semantic))
+    {
+        return;
+    }
+
+    ForgoneMint diagnostic;
+    diagnostic.occurredAtUnixNanos = unixNanosNow();
+    diagnostic.charId              = charId;
+    diagnostic.zoneId              = semantic.zoneId;
+    diagnostic.requestedAmount     = requested;
+    diagnostic.appliedAmount       = applied;
+    diagnostic.forgoneAmount       = requested - applied;
+    diagnostic.category            = category;
+    diagnostic.transactionId       = transactionId;
+    diagnostic.sourceType          = sourceEvent.sourceType;
+    diagnostic.sourceKey           = sourceEvent.sourceKey;
+    diagnostic.context             = sourceEvent.context;
+    diagnostic.attributionQuality  = quality;
+    static_cast<void>(diagnostic.evidenceVersion.assign(EvidenceVersionKey));
+    static_cast<void>(globalProducer().tryRecord(diagnostic));
+}
+
+[[nodiscard]] auto isSafeTokenCharacter(char character) noexcept -> bool
+{
+    const auto alphaNumeric = (character >= 'A' && character <= 'Z') ||
+                              (character >= 'a' && character <= 'z') ||
+                              (character >= '0' && character <= '9');
+    return alphaNumeric || character == '.' || character == '_' || character == ':' || character == '+' ||
+           character == '/' || character == '-';
+}
+
+[[nodiscard]] auto scriptFileFor(const CCharEntity* PChar) noexcept -> std::string_view
+{
+    if (!PChar)
+    {
+        return {};
+    }
+    if (PChar->currentEvent && !PChar->currentEvent->scriptFile.empty())
+    {
+        return PChar->currentEvent->scriptFile;
+    }
+    if (PChar->eventPreparation && !PChar->eventPreparation->scriptFile.empty())
+    {
+        return PChar->eventPreparation->scriptFile;
+    }
+    return {};
+}
+
+[[nodiscard]] auto normalizedScriptKey(std::string_view path) noexcept -> ScriptKey
+{
+    ScriptKey key;
+    while (path.starts_with("./") || path.starts_with(".\\"))
+    {
+        path.remove_prefix(2);
+    }
+
+    constexpr std::string_view ScriptsPrefix = "scripts/";
+    if (const auto scripts = path.find(ScriptsPrefix); scripts != std::string_view::npos)
+    {
+        path.remove_prefix(scripts + ScriptsPrefix.size());
+    }
+    if (path.ends_with(".lua"))
+    {
+        path.remove_suffix(4);
+    }
+
+    std::array<char, 96> normalized{};
+    std::size_t          length{};
+    std::uint64_t        hash = 14695981039346656037ULL;
+    bool                 truncated{};
+    for (const auto rawCharacter : path)
+    {
+        const auto character = rawCharacter == '\\' ? '/' : (isSafeTokenCharacter(rawCharacter) ? rawCharacter : '-');
+        hash ^= static_cast<std::uint8_t>(character);
+        hash *= 1099511628211ULL;
+        if (length < normalized.size())
+        {
+            normalized[length++] = character;
+        }
+        else
+        {
+            truncated = true;
+        }
+    }
+
+    if (length == 0)
+    {
+        static_cast<void>(key.assign("lua-unknown"));
+        return key;
+    }
+    if (!truncated)
+    {
+        static_cast<void>(key.assign({ normalized.data(), length }));
+        return key;
+    }
+
+    constexpr std::size_t      PrefixLength = 71;
+    constexpr std::string_view Marker       = "-fnv1a64-";
+    std::array<char, 96>       hashed{};
+    std::copy_n(normalized.begin(), PrefixLength, hashed.begin());
+    std::copy(Marker.begin(), Marker.end(), hashed.begin() + PrefixLength);
+    auto* const hashBegin = hashed.data() + PrefixLength + Marker.size();
+    const auto  result    = std::to_chars(hashBegin, hashed.data() + hashed.size(), hash, 16);
+    if (result.ec == std::errc{})
+    {
+        static_cast<void>(key.assign({ hashed.data(), static_cast<std::size_t>(result.ptr - hashed.data()) }));
+    }
+    else
+    {
+        static_cast<void>(key.assign("lua-path-hash-error"));
+    }
+    return key;
+}
+
+[[nodiscard]] auto activeSourceHint(const CCharEntity* PChar) noexcept -> SourceHint
+{
+    SourceHint hint;
+    if (!PChar)
+    {
+        return hint;
+    }
+
+    const CBaseEntity* target = nullptr;
+    if (PChar->eventPreparation && PChar->eventPreparation->targetEntity)
+    {
+        target = PChar->eventPreparation->targetEntity;
+    }
+    else if (PChar->currentEvent)
+    {
+        target = PChar->currentEvent->targetEntity;
+    }
+
+    KeyBuilder key;
+    if (target && target->objtype == TYPE_NPC)
+    {
+        key.append("npc:");
+        key.appendNumber(target->getZone());
+        key.append(":");
+        key.appendNumber(target->id);
+        static_cast<void>(hint.assign(key.view()));
+        return hint;
+    }
+    if (target && target->objtype == TYPE_MOB)
+    {
+        key.append("mob:");
+        key.appendNumber(target->id);
+        static_cast<void>(hint.assign(key.view()));
+        return hint;
+    }
+
+    const auto scriptKey = normalizedScriptKey(scriptFileFor(PChar));
+    key.append("script:");
+    key.append(scriptKey.view());
+    static_cast<void>(hint.assign(key.view()));
+    return hint;
+}
+
+[[nodiscard]] auto offeredGil(CCharEntity* PChar) -> std::uint64_t
+{
+    if (!PChar || !PChar->UContainer)
+    {
+        return 0;
+    }
+
+    std::uint64_t amount{};
+    for (std::uint8_t slot = 0; slot <= 8; ++slot)
+    {
+        const auto* item = PChar->UContainer->GetItem(slot);
+        if (item && item->isType(ITEM_CURRENCY))
+        {
+            amount += item->getReserve();
+        }
+    }
+    return amount;
+}
+
+void stopProducerAtExit()
+{
+    globalProducer().stop();
+}
+
+} // namespace
+
+class EconomyTelemetryModule final : public CPPModule
+{
+public:
+    void OnInit() override
+    {
+        auto&      producer = phoenix::economy::globalProducer();
+        const auto result   = producer.startFromEnvironment();
+        if (result == phoenix::economy::StartResult::Started)
+        {
+            std::atexit(&stopProducerAtExit);
+            ShowInfo("Phoenix economy telemetry producer started");
+        }
+        else if (result != phoenix::economy::StartResult::Disabled &&
+                 result != phoenix::economy::StartResult::AlreadyStarted)
+        {
+            ShowWarningFmt("Phoenix economy telemetry producer did not start: {}", producer.lastError());
+        }
+
+        auto xiTable      = lua["xi"].get_or_create<sol::table>();
+        auto economyTable = xiTable["economy"].get_or_create<sol::table>();
+        economyTable.set_function("enabled", []() -> bool
+                                  {
+                                      return phoenix::economy::globalProducer().enabled();
+                                  });
+
+        if (!producer.enabled())
+        {
+            return;
+        }
+
+        economyTable.set_function("beginContext", [this](CLuaBaseEntity* entity, const sol::table& table) -> bool
+                                  {
+                                      auto* PChar = luaCharacter(entity);
+                                      auto* state = ensureState(PChar);
+                                      if (!state)
+                                      {
+                                          return false;
+                                      }
+
+                                      if (state->contextScope.suppressionDepth > 0 ||
+                                          state->contextScope.depth >= MaxSemanticContextDepth)
+                                      {
+                                          return correlator::beginContext(
+                                                     state->contextScope, MaxSemanticContextDepth, false) !=
+                                                 correlator::ContextBegin::Rejected;
+                                      }
+
+                                      const auto context = parseSemanticContext(PChar, table);
+                                      const auto begin   = correlator::beginContext(
+                                          state->contextScope, MaxSemanticContextDepth, context.has_value());
+                                      if (begin == correlator::ContextBegin::Rejected)
+                                      {
+                                          return false;
+                                      }
+                                      if (begin == correlator::ContextBegin::Pushed)
+                                      {
+                                          state->contexts[state->contextScope.depth - 1] = *context;
+                                      }
+                                      return true;
+                                  });
+
+        economyTable.set_function("endContext", [this](CLuaBaseEntity* entity)
+                                  {
+                                      auto* PChar = luaCharacter(entity);
+                                      auto* state = PChar ? findState(PChar->id) : nullptr;
+                                      if (state && correlator::endContext(state->contextScope) == correlator::ContextEnd::Popped)
+                                      {
+                                          state->contexts[state->contextScope.depth] = {};
+                                      }
+                                  });
+
+        economyTable.set_function("beginLuaWallet", [this](CLuaBaseEntity* entity) -> bool
+                                  {
+                                      auto* state = ensureState(luaCharacter(entity));
+                                      if (!state || state->luaMutationDepth == std::numeric_limits<std::uint8_t>::max())
+                                      {
+                                          return false;
+                                      }
+                                      ++state->luaMutationDepth;
+                                      return true;
+                                  });
+
+        economyTable.set_function("endLuaWallet",
+                                  [this](CLuaBaseEntity*  entity,
+                                         std::uint64_t    before,
+                                         std::uint64_t    after,
+                                         std::int64_t     requested,
+                                         std::string_view operation)
+                                  {
+                                      auto* PChar = luaCharacter(entity);
+                                      auto* state = PChar ? findState(PChar->id) : nullptr;
+                                      if (!PChar || !state)
+                                      {
+                                          return;
+                                      }
+                                      if (state->luaMutationDepth > 0)
+                                      {
+                                          --state->luaMutationDepth;
+                                      }
+                                      recordLuaWallet(*state, PChar, before, after, requested, operation);
+                                  });
+
+        economyTable.set_function("captureShop", [this](CLuaBaseEntity* entity)
+                                  {
+                                      captureShop(luaCharacter(entity));
+                                  });
+
+        economyTable.set_function("stageMobDeath", [this](CLuaBaseEntity* player, CLuaBaseEntity* mob)
+                                  {
+                                      stageMobDeath(luaCharacter(player), luaMob(mob));
+                                  });
+    }
+
+    void OnCharZoneIn(CCharEntity* PChar) override
+    {
+        if (!globalProducer().enabled())
+        {
+            return;
+        }
+        if (auto* state = ensureState(PChar); state)
+        {
+            state->zoneId = PChar->getZone();
+            if (const auto gil = walletGil(PChar); gil)
+            {
+                state->walletShadow      = *gil;
+                state->walletShadowValid = true;
+            }
+        }
+    }
+
+    void OnCharZoneOut(CCharEntity* PChar) override
+    {
+        if (!PChar)
+        {
+            return;
+        }
+        if (auto* state = findState(PChar->id); state)
+        {
+            expireAllPending(*state, "zone-out-unconfirmed");
+            *state           = {};
+            state->slotState = SlotState::Tombstone;
+        }
+    }
+
+    auto OnIncomingPacket(MapSession* session, CCharEntity* PChar, CBasicPacket& packet) -> bool override
+    {
+        if (!globalProducer().enabled() || !session || !PChar)
+        {
+            return false;
+        }
+
+        auto* state = ensureState(PChar);
+        if (!state)
+        {
+            return false;
+        }
+        synchronizeShadow(*state, PChar, "incoming-shadow-desync");
+
+        switch (static_cast<PacketC2S>(packet.getType()))
+        {
+            case PacketC2S::GP_CLI_COMMAND_SHOP_BUY:
+                stageShopBuy(*state, PChar, *packet.as<GP_CLI_COMMAND_SHOP_BUY>());
+                break;
+            case PacketC2S::GP_CLI_COMMAND_SHOP_SELL_SET:
+                stageShopSell(*state, PChar);
+                break;
+            case PacketC2S::GP_CLI_COMMAND_BAZAAR_BUY:
+                stageBazaar(*state, PChar, *packet.as<GP_CLI_COMMAND_BAZAAR_BUY>());
+                break;
+            case PacketC2S::GP_CLI_COMMAND_TRADE_RES:
+                stageTrade(*state, PChar, *packet.as<GP_CLI_COMMAND_TRADE_RES>());
+                break;
+            case PacketC2S::GP_CLI_COMMAND_AUC:
+            {
+                const auto& auctionPacket = *packet.as<GP_CLI_COMMAND_AUC>();
+                if (auctionPacket.Command == GP_CLI_COMMAND_AUC_COMMAND::LotIn)
+                {
+                    stageAuctionListing(*state, PChar, auctionPacket);
+                }
+                break;
+            }
+            default:
+                break;
+        }
+
+        // Core and later modules always retain transaction ownership.
+        return false;
+    }
+
+    void OnPushPacket(CCharEntity* PChar, const std::unique_ptr<CBasicPacket>& packet) override
+    {
+        if (!globalProducer().enabled() || !PChar || !packet)
+        {
+            return;
+        }
+
+        auto* state = ensureState(PChar);
+        if (!state)
+        {
+            return;
+        }
+
+        const auto packetType = static_cast<PacketS2C>(packet->getType());
+        if (packetType == PacketS2C::GP_SERV_COMMAND_ITEM_NUM && packet->getSize() >= 12 &&
+            packet->ref<std::uint8_t>(8) == LOC_INVENTORY && packet->ref<std::uint8_t>(9) == 0)
+        {
+            observeWalletPacket(*state, packet->ref<std::uint32_t>(4));
+            return;
+        }
+
+        switch (packetType)
+        {
+            case PacketS2C::GP_SERV_COMMAND_SHOP_BUY:
+                if (packet->getSize() >= 12)
+                {
+                    if (auto* pending = uniquePending(*state, NativeOperation::ShopBuy); pending)
+                    {
+                        pending->semantic.itemQuantity.set(packet->ref<std::uint32_t>(8));
+                        pending->resultObserved = true;
+                        finalizeSingle(*state, *pending);
+                    }
+                }
+                break;
+            case PacketS2C::GP_SERV_COMMAND_ITEM_SAME:
+                if (auto* pending = uniquePending(*state, NativeOperation::ShopSell); pending)
+                {
+                    pending->resultObserved = true;
+                    finalizeSingle(*state, *pending);
+                }
+                break;
+            case PacketS2C::GP_SERV_COMMAND_AUC:
+                if (packet->getSize() >= 8 &&
+                    packet->ref<GP_CLI_COMMAND_AUC_COMMAND>(4) == GP_CLI_COMMAND_AUC_COMMAND::LotIn &&
+                    packet->ref<std::uint8_t>(6) == 1)
+                {
+                    if (auto* pending = uniquePending(*state, NativeOperation::AuctionListing); pending)
+                    {
+                        pending->resultObserved = true;
+                        finalizeSingle(*state, *pending);
+                    }
+                }
+                break;
+            case PacketS2C::GP_SERV_COMMAND_BAZAAR_BUY:
+                if (packet->getSize() >= 8)
+                {
+                    auto* pending = uniquePending(*state, NativeOperation::Bazaar);
+                    if (packet->ref<std::uint32_t>(4) == 0)
+                    {
+                        if (pending)
+                        {
+                            pending->resultObserved = true;
+                            finalizeBazaar(*state, *pending);
+                        }
+                    }
+                    else if (pending)
+                    {
+                        expirePending(*state, *pending, "bazaar-rejected-after-wallet");
+                    }
+                }
+                break;
+            case PacketS2C::GP_SERV_COMMAND_ITEM_TRADE_RES:
+                if (packet->getSize() >= 12)
+                {
+                    const auto kind = packet->ref<GP_ITEM_TRADE_RES_KIND>(8);
+                    if (auto* pending = uniquePending(*state, NativeOperation::PlayerTrade); pending)
+                    {
+                        if (kind == GP_ITEM_TRADE_RES_KIND::End)
+                        {
+                            pending->resultObserved = true;
+                            finalizeTrade(*state, *pending);
+                        }
+                        else if (kind == GP_ITEM_TRADE_RES_KIND::Cancell || kind == GP_ITEM_TRADE_RES_KIND::MakeCancell ||
+                                 kind == GP_ITEM_TRADE_RES_KIND::ErrEtc || kind == GP_ITEM_TRADE_RES_KIND::ErrNoSearchYou ||
+                                 kind == GP_ITEM_TRADE_RES_KIND::ErrNowReq || kind == GP_ITEM_TRADE_RES_KIND::ErrYouTrade ||
+                                 kind == GP_ITEM_TRADE_RES_KIND::ErrLogout)
+                        {
+                            expirePending(*state, *pending, "trade-cancelled-after-wallet");
+                        }
+                    }
+                }
+                break;
+            case PacketS2C::GP_SERV_COMMAND_BATTLE_MESSAGE:
+                observeMobGilMessage(*state, packet.get());
+                break;
+            default:
+                break;
+        }
+    }
+
+    void OnZoneTick(CZone* PZone) override
+    {
+        if (!globalProducer().enabled() || !PZone)
+        {
+            return;
+        }
+
+        const auto now = SteadyClock::now();
+        if (now < nextExpirySweep_)
+        {
+            return;
+        }
+        nextExpirySweep_ = now + ExpirySweepInterval;
+
+        for (auto& state : characters_)
+        {
+            if (state.slotState != SlotState::Occupied)
+            {
+                continue;
+            }
+            if (state.shop.active && state.shop.deadline <= now)
+            {
+                state.shop = {};
+            }
+
+            for (auto& pending : state.pending)
+            {
+                if (!pending.active || pending.deadline > now)
+                {
+                    continue;
+                }
+                if (pending.role == PairRole::Second && findPeerPending(pending))
+                {
+                    continue;
+                }
+                expirePending(state, pending, "packet-correlation-expired");
+            }
+        }
+    }
+
+    void OnTimeServerTick() override
+    {
+        globalProducer().noteGameTick();
+    }
+
+private:
+    [[nodiscard]] auto findState(std::uint32_t charId) -> CharacterState*
+    {
+        if (charId == 0)
+        {
+            return nullptr;
+        }
+
+        const auto start = (static_cast<std::size_t>(charId) * 2654435761U) & (MaxTrackedCharacters - 1);
+        for (std::size_t probe = 0; probe < MaxTrackedCharacters; ++probe)
+        {
+            auto& state = characters_[(start + probe) & (MaxTrackedCharacters - 1)];
+            if (state.slotState == SlotState::Empty)
+            {
+                return nullptr;
+            }
+            if (state.slotState == SlotState::Occupied && state.charId == charId)
+            {
+                return &state;
+            }
+        }
+        return nullptr;
+    }
+
+    [[nodiscard]] auto ensureState(CCharEntity* PChar) -> CharacterState*
+    {
+        if (!PChar || PChar->id == 0)
+        {
+            return nullptr;
+        }
+        if (auto* existing = findState(PChar->id); existing)
+        {
+            existing->zoneId = PChar->getZone();
+            return existing;
+        }
+
+        const auto      start     = (static_cast<std::size_t>(PChar->id) * 2654435761U) & (MaxTrackedCharacters - 1);
+        CharacterState* tombstone = nullptr;
+        for (std::size_t probe = 0; probe < MaxTrackedCharacters; ++probe)
+        {
+            auto& state = characters_[(start + probe) & (MaxTrackedCharacters - 1)];
+            if (state.slotState == SlotState::Tombstone && !tombstone)
+            {
+                tombstone = &state;
+                continue;
+            }
+            if (state.slotState != SlotState::Empty)
+            {
+                continue;
+            }
+
+            auto* destination      = tombstone ? tombstone : &state;
+            *destination           = {};
+            destination->slotState = SlotState::Occupied;
+            destination->charId    = PChar->id;
+            destination->zoneId    = PChar->getZone();
+            if (const auto gil = walletGil(PChar); gil)
+            {
+                destination->walletShadow      = *gil;
+                destination->walletShadowValid = true;
+            }
+            return destination;
+        }
+
+        if (tombstone)
+        {
+            *tombstone           = {};
+            tombstone->slotState = SlotState::Occupied;
+            tombstone->charId    = PChar->id;
+            tombstone->zoneId    = PChar->getZone();
+            if (const auto gil = walletGil(PChar); gil)
+            {
+                tombstone->walletShadow      = *gil;
+                tombstone->walletShadowValid = true;
+            }
+            return tombstone;
+        }
+        return nullptr;
+    }
+
+    void synchronizeShadow(CharacterState& state, CCharEntity* PChar, std::string_view detail)
+    {
+        const auto current = walletGil(PChar);
+        if (!current)
+        {
+            return;
+        }
+        if (state.walletShadowValid && state.walletShadow != *current)
+        {
+            const auto hint = activeSourceHint(PChar);
+            recordGap(state.charId, state.zoneId, state.walletShadow, *current, EvidenceType::WalletObserver, detail, hint.view());
+        }
+        state.walletShadow      = *current;
+        state.walletShadowValid = true;
+    }
+
+    [[nodiscard]] auto allocatePending(CharacterState& state, NativeOperation operation) -> PendingOperation*
+    {
+        for (auto& existing : state.pending)
+        {
+            if (existing.active && existing.operation == operation)
+            {
+                expirePending(state, existing, "superseded-native-operation");
+                break;
+            }
+        }
+        for (auto& pending : state.pending)
+        {
+            if (!pending.active)
+            {
+                pending           = {};
+                pending.active    = true;
+                pending.operation = operation;
+                pending.beforeGil = state.walletShadow;
+                pending.latestGil = state.walletShadow;
+                pending.deadline  = SteadyClock::now() + NativeDeadline;
+                return &pending;
+            }
+        }
+        state.pendingOverflow = true;
+        return nullptr;
+    }
+
+    [[nodiscard]] auto uniquePending(CharacterState& state, NativeOperation operation) -> PendingOperation*
+    {
+        PendingOperation* result = nullptr;
+        for (auto& pending : state.pending)
+        {
+            if (!pending.active || pending.operation != operation)
+            {
+                continue;
+            }
+            if (result)
+            {
+                result->ambiguous = true;
+                pending.ambiguous = true;
+                return nullptr;
+            }
+            result = &pending;
+        }
+        return result;
+    }
+
+    [[nodiscard]] auto findPendingByTransaction(CharacterState& state, const TransactionId& transactionId) -> PendingOperation*
+    {
+        for (auto& pending : state.pending)
+        {
+            if (pending.active && pending.transactionId.view() == transactionId.view())
+            {
+                return &pending;
+            }
+        }
+        return nullptr;
+    }
+
+    [[nodiscard]] auto findPeerPending(const PendingOperation& pending) -> PendingOperation*
+    {
+        const auto peerId    = pending.role == PairRole::First ? pending.secondCharId : pending.firstCharId;
+        auto*      peerState = findState(peerId);
+        return peerState ? findPendingByTransaction(*peerState, pending.transactionId) : nullptr;
+    }
+
+    void clearTransaction(const PendingOperation& pending)
+    {
+        const auto transactionId = pending.transactionId;
+        const auto firstId       = pending.firstCharId;
+        const auto secondId      = pending.secondCharId;
+        if (auto* first = findState(firstId); first)
+        {
+            if (auto* local = findPendingByTransaction(*first, transactionId); local)
+            {
+                *local = {};
+            }
+        }
+        if (secondId != 0)
+        {
+            if (auto* second = findState(secondId); second)
+            {
+                if (auto* local = findPendingByTransaction(*second, transactionId); local)
+                {
+                    *local = {};
+                }
+            }
+        }
+    }
+
+    void gapPendingLocal(CharacterState& state, PendingOperation& pending, std::string_view detail)
+    {
+        if (pending.gapReported ||
+            correlator::expiryStatus(pending.walletObserved, pending.beforeGil, pending.latestGil) != correlator::Status::Gap)
+        {
+            return;
+        }
+        recordGap(state.charId,
+                  state.zoneId,
+                  pending.beforeGil,
+                  pending.latestGil,
+                  EvidenceType::PacketCorrelator,
+                  detail,
+                  operationHint(pending.operation));
+        pending.gapReported = true;
+    }
+
+    void expirePending(CharacterState& state, PendingOperation& pending, std::string_view detail)
+    {
+        if (!pending.active)
+        {
+            return;
+        }
+        gapPendingLocal(state, pending, detail);
+        if (auto* peer = findPeerPending(pending); peer)
+        {
+            const auto peerId = pending.role == PairRole::First ? pending.secondCharId : pending.firstCharId;
+            if (auto* peerState = findState(peerId); peerState)
+            {
+                gapPendingLocal(*peerState, *peer, detail);
+            }
+        }
+        clearTransaction(pending);
+    }
+
+    void expireAllPending(CharacterState& state, std::string_view detail)
+    {
+        for (auto& pending : state.pending)
+        {
+            if (pending.active)
+            {
+                expirePending(state, pending, detail);
+            }
+        }
+    }
+
+    [[nodiscard]] static auto operationHint(NativeOperation operation) -> std::string_view
+    {
+        switch (operation)
+        {
+            case NativeOperation::ShopBuy:
+                return "packet:shop-buy";
+            case NativeOperation::ShopSell:
+                return "packet:shop-sell";
+            case NativeOperation::Bazaar:
+                return "packet:bazaar";
+            case NativeOperation::PlayerTrade:
+                return "packet:player-trade";
+            case NativeOperation::AuctionListing:
+                return "packet:auction-listing";
+            case NativeOperation::MobDrop:
+                return "packet:mob-drop";
+        }
+        return "packet:unknown";
+    }
+
+    void observeWalletPacket(CharacterState& state, std::uint64_t newGil)
+    {
+        if (state.luaMutationDepth > 0)
+        {
+            return;
+        }
+        if (!state.walletShadowValid)
+        {
+            state.walletShadow      = newGil;
+            state.walletShadowValid = true;
+            return;
+        }
+
+        const auto before  = state.walletShadow;
+        state.walletShadow = newGil;
+
+        std::array<PendingOperation*, MaxPendingPerCharacter> candidates{};
+        std::size_t                                           candidateCount{};
+        for (auto& pending : state.pending)
+        {
+            if (pending.active)
+            {
+                candidates[candidateCount++] = &pending;
+            }
+        }
+
+        if (state.pendingOverflow)
+        {
+            if (before != newGil)
+            {
+                recordGap(state.charId,
+                          state.zoneId,
+                          before,
+                          newGil,
+                          EvidenceType::WalletObserver,
+                          "pending-context-overflow",
+                          "packet:overflow");
+            }
+            state.pendingOverflow = false;
+            for (std::size_t index = 0; index < candidateCount; ++index)
+            {
+                candidates[index]->ambiguous = true;
+            }
+            return;
+        }
+
+        if (candidateCount == 0)
+        {
+            if (before != newGil)
+            {
+                recordGap(state.charId,
+                          state.zoneId,
+                          before,
+                          newGil,
+                          EvidenceType::WalletObserver,
+                          "unmatched-wallet-packet",
+                          "packet:item-num");
+            }
+            return;
+        }
+
+        if (candidateCount > 1)
+        {
+            if (before != newGil)
+            {
+                recordGap(state.charId,
+                          state.zoneId,
+                          before,
+                          newGil,
+                          EvidenceType::PacketCorrelator,
+                          "ambiguous-wallet-packet",
+                          "packet:item-num");
+            }
+            for (std::size_t index = 0; index < candidateCount; ++index)
+            {
+                auto* pending           = candidates[index];
+                pending->ambiguous      = true;
+                pending->walletObserved = true;
+                pending->latestGil      = newGil;
+                pending->gapReported    = before != newGil;
+            }
+            return;
+        }
+
+        auto& pending          = *candidates[0];
+        pending.walletObserved = true;
+        pending.latestGil      = newGil;
+        ++pending.walletPacketCount;
+        if (pending.resultObserved)
+        {
+            if (pending.operation == NativeOperation::ShopBuy || pending.operation == NativeOperation::ShopSell ||
+                pending.operation == NativeOperation::AuctionListing)
+            {
+                finalizeSingle(state, pending);
+            }
+            else if (pending.operation == NativeOperation::Bazaar)
+            {
+                finalizeBazaar(state, pending);
+            }
+            else if (pending.operation == NativeOperation::PlayerTrade)
+            {
+                finalizeTrade(state, pending);
+            }
+        }
+    }
+
+    void finalizeSingle(CharacterState& state, PendingOperation& pending)
+    {
+        if (!pending.active || !pending.resultObserved || !pending.walletObserved)
+        {
+            return;
+        }
+        if (pending.ambiguous)
+        {
+            expirePending(state, pending, "ambiguous-single-operation");
+            return;
+        }
+
+        const auto            before = pending.beforeGil;
+        const auto            after  = pending.latestGil;
+        Category              category{};
+        correlator::Direction expectedDirection{};
+        switch (pending.operation)
+        {
+            case NativeOperation::ShopBuy:
+                category          = Category::NpcShopPurchase;
+                expectedDirection = correlator::Direction::Debit;
+                break;
+            case NativeOperation::ShopSell:
+                category          = Category::NpcVendorSale;
+                expectedDirection = correlator::Direction::Credit;
+                break;
+            case NativeOperation::AuctionListing:
+                category          = Category::AuctionListingFee;
+                expectedDirection = correlator::Direction::Debit;
+                break;
+            default:
+                expirePending(state, pending, "invalid-single-operation");
+                return;
+        }
+
+        const auto reconciliation = correlator::reconcileSingle(before, after, expectedDirection);
+        if (reconciliation.status == correlator::Status::NoChange)
+        {
+            if (pending.operation == NativeOperation::ShopSell && pending.expectedBaseAmount > 0)
+            {
+                recordForgoneMint(Category::NpcVendorSale,
+                                  pending.expectedBaseAmount,
+                                  0,
+                                  state.charId,
+                                  pending.semantic,
+                                  pending.transactionId,
+                                  AttributionQuality::Correlated);
+            }
+            pending = {};
+            return;
+        }
+
+        if (reconciliation.status != correlator::Status::Complete)
+        {
+            expirePending(state, pending, "single-operation-direction-mismatch");
+            return;
+        }
+
+        const auto amount = reconciliation.amount;
+        if (pending.operation == NativeOperation::ShopSell && pending.expectedBaseAmount > 0 &&
+            amount > pending.expectedBaseAmount)
+        {
+            expirePending(state, pending, "shop-sell-amount-mismatch");
+            return;
+        }
+        if (kindForCategory(category) == Kind::Mint)
+        {
+            recordEvent(category,
+                        amount,
+                        pending.semantic,
+                        pending.transactionId,
+                        std::nullopt,
+                        state.charId,
+                        AttributionQuality::Correlated);
+        }
+        else
+        {
+            recordEvent(category,
+                        amount,
+                        pending.semantic,
+                        pending.transactionId,
+                        state.charId,
+                        std::nullopt,
+                        AttributionQuality::Correlated);
+        }
+        if (pending.operation == NativeOperation::ShopSell && pending.expectedBaseAmount > amount)
+        {
+            recordForgoneMint(Category::NpcVendorSale,
+                              pending.expectedBaseAmount,
+                              amount,
+                              state.charId,
+                              pending.semantic,
+                              pending.transactionId,
+                              AttributionQuality::Correlated);
+        }
+        pending = {};
+    }
+
+    void finalizeBazaar(CharacterState& state, PendingOperation& pending)
+    {
+        if (!pending.active || pending.role != PairRole::First || !pending.resultObserved)
+        {
+            return;
+        }
+        auto* peerState = findState(pending.secondCharId);
+        auto* peer      = peerState ? findPendingByTransaction(*peerState, pending.transactionId) : nullptr;
+        if (!peer || !pending.walletObserved || !peer->walletObserved)
+        {
+            return;
+        }
+        if (pending.ambiguous || peer->ambiguous)
+        {
+            expirePending(state, pending, "ambiguous-bazaar-reconciliation");
+            return;
+        }
+
+        const auto buyerBefore    = pending.beforeGil;
+        const auto buyerAfter     = pending.latestGil;
+        const auto sellerBefore   = peer->beforeGil;
+        const auto sellerAfter    = peer->latestGil;
+        const auto reconciliation = correlator::reconcileBazaar(
+            buyerBefore, buyerAfter, sellerBefore, sellerAfter, pending.expectedBaseAmount);
+        if (reconciliation.status != correlator::Status::Complete)
+        {
+            expirePending(state, pending, "bazaar-leg-mismatch");
+            return;
+        }
+
+        if (reconciliation.transfer > 0)
+        {
+            recordEvent(Category::BazaarSale,
+                        reconciliation.transfer,
+                        pending.semantic,
+                        pending.transactionId,
+                        pending.firstCharId,
+                        pending.secondCharId,
+                        AttributionQuality::Correlated);
+        }
+        if (reconciliation.tax > 0)
+        {
+            recordEvent(Category::BazaarTax,
+                        reconciliation.tax,
+                        pending.semantic,
+                        pending.transactionId,
+                        pending.firstCharId,
+                        std::nullopt,
+                        AttributionQuality::Correlated);
+        }
+        if (reconciliation.capLoss > 0)
+        {
+            recordEvent(Category::CurrencyCapLoss,
+                        reconciliation.capLoss,
+                        pending.semantic,
+                        pending.transactionId,
+                        pending.firstCharId,
+                        std::nullopt,
+                        AttributionQuality::Correlated);
+        }
+        clearTransaction(pending);
+    }
+
+    void finalizeTrade(CharacterState& state, PendingOperation& pending)
+    {
+        auto* peerState = findState(pending.role == PairRole::First ? pending.secondCharId : pending.firstCharId);
+        auto* peer      = peerState ? findPendingByTransaction(*peerState, pending.transactionId) : nullptr;
+        if (!peer || !pending.resultObserved || !peer->resultObserved)
+        {
+            return;
+        }
+
+        auto* firstState  = findState(pending.firstCharId);
+        auto* secondState = findState(pending.secondCharId);
+        auto* first       = firstState ? findPendingByTransaction(*firstState, pending.transactionId) : nullptr;
+        auto* second      = secondState ? findPendingByTransaction(*secondState, pending.transactionId) : nullptr;
+        if (!firstState || !secondState || !first || !second)
+        {
+            expirePending(state, pending, "trade-counterpart-missing");
+            return;
+        }
+        if ((pending.firstOffer > 0 || pending.secondOffer > 0) && (!first->walletObserved || !second->walletObserved))
+        {
+            return;
+        }
+        if (first->ambiguous || second->ambiguous)
+        {
+            expirePending(*firstState, *first, "ambiguous-trade-reconciliation");
+            return;
+        }
+        if (pending.firstOffer == 0 && pending.secondOffer == 0)
+        {
+            clearTransaction(*first);
+            return;
+        }
+
+        const auto reconciliation = correlator::reconcileTrade(pending.firstBefore,
+                                                               first->latestGil,
+                                                               pending.secondBefore,
+                                                               second->latestGil,
+                                                               pending.firstOffer,
+                                                               pending.secondOffer);
+        if (reconciliation.status != correlator::Status::Complete)
+        {
+            expirePending(*firstState, *first, "trade-leg-mismatch");
+            return;
+        }
+
+        if (reconciliation.firstToSecond > 0)
+        {
+            recordEvent(Category::PlayerTrade,
+                        reconciliation.firstToSecond,
+                        pending.semantic,
+                        pending.transactionId,
+                        pending.firstCharId,
+                        pending.secondCharId,
+                        AttributionQuality::Correlated);
+        }
+        if (reconciliation.firstCapLoss > 0)
+        {
+            recordEvent(Category::CurrencyCapLoss,
+                        reconciliation.firstCapLoss,
+                        pending.semantic,
+                        pending.transactionId,
+                        pending.firstCharId,
+                        std::nullopt,
+                        AttributionQuality::Correlated);
+        }
+        if (reconciliation.secondToFirst > 0)
+        {
+            recordEvent(Category::PlayerTrade,
+                        reconciliation.secondToFirst,
+                        pending.semantic,
+                        pending.transactionId,
+                        pending.secondCharId,
+                        pending.firstCharId,
+                        AttributionQuality::Correlated);
+        }
+        if (reconciliation.secondCapLoss > 0)
+        {
+            recordEvent(Category::CurrencyCapLoss,
+                        reconciliation.secondCapLoss,
+                        pending.semantic,
+                        pending.transactionId,
+                        pending.secondCharId,
+                        std::nullopt,
+                        AttributionQuality::Correlated);
+        }
+        clearTransaction(*first);
+    }
+
+    void observeMobGilMessage(CharacterState& state, CBasicPacket* packet)
+    {
+        const auto* message = dynamic_cast<const GP_SERV_COMMAND_BATTLE_MESSAGE*>(packet);
+        if (!message || message->getMessageId() != MsgBasic::Obtains || packet->getSize() < 16)
+        {
+            return;
+        }
+
+        auto* pending = uniquePending(state, NativeOperation::MobDrop);
+        if (!pending || !pending->walletObserved)
+        {
+            return;
+        }
+        const auto requested = packet->ref<std::uint32_t>(12);
+        if (pending->ambiguous || pending->latestGil < pending->beforeGil)
+        {
+            expirePending(state, *pending, "ambiguous-mob-gil-correlation");
+            return;
+        }
+
+        const auto applied = pending->latestGil - pending->beforeGil;
+        if (applied > requested)
+        {
+            expirePending(state, *pending, "mob-gil-message-mismatch");
+            return;
+        }
+        if (applied > 0)
+        {
+            recordEvent(Category::MobDrop,
+                        applied,
+                        pending->semantic,
+                        pending->transactionId,
+                        std::nullopt,
+                        state.charId,
+                        AttributionQuality::Correlated);
+        }
+        if (requested > applied)
+        {
+            recordForgoneMint(Category::MobDrop,
+                              requested,
+                              applied,
+                              state.charId,
+                              pending->semantic,
+                              pending->transactionId,
+                              AttributionQuality::Correlated);
+        }
+        *pending = {};
+    }
+
+    void recordLuaWallet(CharacterState&  state,
+                         CCharEntity*     PChar,
+                         std::uint64_t    before,
+                         std::uint64_t    after,
+                         std::int64_t     requested,
+                         std::string_view operation)
+    {
+        if (state.walletShadowValid && state.walletShadow != before)
+        {
+            const auto hint = activeSourceHint(PChar);
+            recordGap(state.charId,
+                      state.zoneId,
+                      state.walletShadow,
+                      before,
+                      EvidenceType::WalletObserver,
+                      "lua-shadow-desync",
+                      hint.view());
+        }
+        state.walletShadow      = after;
+        state.walletShadowValid = true;
+
+        if (before != after)
+        {
+            for (auto& pending : state.pending)
+            {
+                if (pending.active)
+                {
+                    pending.ambiguous = true;
+                }
+            }
+        }
+
+        const auto* semantic = correlator::semanticContextUsable(state.contextScope) ? &state.contexts[state.contextScope.depth - 1] : nullptr;
+        if (before == after)
+        {
+            if (semantic && semantic->mintCategory && requested > 0)
+            {
+                std::uint64_t intended{};
+                if (operation == "add")
+                {
+                    intended = static_cast<std::uint64_t>(requested);
+                }
+                else if (operation == "set" && static_cast<std::uint64_t>(requested) > before)
+                {
+                    intended = static_cast<std::uint64_t>(requested) - before;
+                }
+                recordForgoneMint(*semantic->mintCategory,
+                                  intended,
+                                  0,
+                                  state.charId,
+                                  *semantic,
+                                  semantic->transactionId,
+                                  AttributionQuality::Semantic);
+            }
+            return;
+        }
+
+        if (!semantic)
+        {
+            const auto hint = activeSourceHint(PChar);
+            recordGap(state.charId,
+                      state.zoneId,
+                      before,
+                      after,
+                      EvidenceType::LuaWallet,
+                      state.contextScope.suppressionDepth > 0 ? "lua-context-rejected" : (after > before ? "lua-unattributed-credit" : "lua-unattributed-debit"),
+                      hint.view());
+            return;
+        }
+
+        if (after > before)
+        {
+            if (!semantic->mintCategory)
+            {
+                recordGap(state.charId,
+                          state.zoneId,
+                          before,
+                          after,
+                          EvidenceType::LuaWallet,
+                          "lua-credit-missing-category");
+                return;
+            }
+            const auto applied = after - before;
+            recordEvent(*semantic->mintCategory,
+                        applied,
+                        *semantic,
+                        semantic->transactionId,
+                        std::nullopt,
+                        state.charId,
+                        AttributionQuality::Semantic);
+
+            std::uint64_t intended{};
+            if (operation == "add" && requested > 0)
+            {
+                intended = static_cast<std::uint64_t>(requested);
+            }
+            else if (operation == "set" && requested > 0 && static_cast<std::uint64_t>(requested) > before)
+            {
+                intended = static_cast<std::uint64_t>(requested) - before;
+            }
+            if (intended > applied)
+            {
+                recordForgoneMint(*semantic->mintCategory,
+                                  intended,
+                                  applied,
+                                  state.charId,
+                                  *semantic,
+                                  semantic->transactionId,
+                                  AttributionQuality::Semantic);
+            }
+        }
+        else
+        {
+            if (!semantic->burnCategory)
+            {
+                recordGap(state.charId,
+                          state.zoneId,
+                          before,
+                          after,
+                          EvidenceType::LuaWallet,
+                          "lua-debit-missing-category");
+                return;
+            }
+            recordEvent(*semantic->burnCategory,
+                        before - after,
+                        *semantic,
+                        semantic->transactionId,
+                        state.charId,
+                        std::nullopt,
+                        AttributionQuality::Semantic);
+        }
+    }
+
+    void captureShop(CCharEntity* PChar)
+    {
+        auto* state = ensureState(PChar);
+        if (!state || !PChar)
+        {
+            return;
+        }
+
+        CBaseEntity* target = nullptr;
+        if (PChar->eventPreparation && PChar->eventPreparation->targetEntity)
+        {
+            target = PChar->eventPreparation->targetEntity;
+        }
+        else if (PChar->currentEvent)
+        {
+            target = PChar->currentEvent->targetEntity;
+        }
+
+        state->shop = {};
+        if (!target || target->objtype != TYPE_NPC)
+        {
+            return;
+        }
+
+        state->shop.active              = true;
+        state->shop.deadline            = SteadyClock::now() + ShopDeadline;
+        state->shop.semantic.sourceType = SourceType::Npc;
+        state->shop.semantic.zoneId.set(target->getZone());
+        state->shop.semantic.source.npcId.set(target->id);
+    }
+
+    void stageMobDeath(CCharEntity* PChar, CMobEntity* PMob)
+    {
+        if (!PChar || !PMob)
+        {
+            return;
+        }
+        auto* state = ensureState(PChar);
+        if (!state)
+        {
+            return;
+        }
+        synchronizeShadow(*state, PChar, "mob-stage-shadow-desync");
+        if (auto* prior = uniquePending(*state, NativeOperation::MobDrop); prior)
+        {
+            expirePending(*state, *prior, "mob-context-superseded");
+        }
+
+        auto* pending = allocatePending(*state, NativeOperation::MobDrop);
+        if (!pending)
+        {
+            return;
+        }
+        pending->deadline            = SteadyClock::now() + MobDeadline;
+        pending->transactionId       = globalProducer().nextTransactionId("mob");
+        pending->firstCharId         = PChar->id;
+        pending->firstBefore         = state->walletShadow;
+        pending->semantic.sourceType = SourceType::Mob;
+        pending->semantic.zoneId.set(PMob->getZone());
+        pending->semantic.source.mobSpawnId.set(PMob->id);
+        if (PMob->m_Pool > 0)
+        {
+            pending->semantic.source.mobPoolId.set(PMob->m_Pool);
+        }
+    }
+
+    void stageShopBuy(CharacterState& state, CCharEntity* PChar, const GP_CLI_COMMAND_SHOP_BUY& packet)
+    {
+        const auto now = SteadyClock::now();
+        if (!state.shop.active || state.shop.deadline <= now || !PChar->Container ||
+            packet.ShopItemIndex >= PChar->Container->getExSize())
+        {
+            state.shop = {};
+            return;
+        }
+
+        auto* pending = allocatePending(state, NativeOperation::ShopBuy);
+        if (!pending)
+        {
+            return;
+        }
+        pending->transactionId = globalProducer().nextTransactionId("shop-buy");
+        pending->firstCharId   = state.charId;
+        pending->firstBefore   = state.walletShadow;
+        pending->semantic      = state.shop.semantic;
+        pending->semantic.source.shopId.set(packet.ShopNo);
+        std::uint16_t itemId = 0;
+        if (packet.ShopItemIndex <= std::numeric_limits<uint8>::max())
+        {
+            itemId = PChar->Container->getItemID(static_cast<uint8>(packet.ShopItemIndex));
+        }
+        if (itemId > 0)
+        {
+            pending->semantic.itemId.set(itemId);
+        }
+    }
+
+    void stageShopSell(CharacterState& state, CCharEntity* PChar)
+    {
+        const auto now = SteadyClock::now();
+        if (!state.shop.active || state.shop.deadline <= now || !PChar->Container)
+        {
+            state.shop = {};
+            return;
+        }
+
+        auto* pending = allocatePending(state, NativeOperation::ShopSell);
+        if (!pending)
+        {
+            return;
+        }
+        pending->transactionId = globalProducer().nextTransactionId("shop-sell");
+        pending->firstCharId   = state.charId;
+        pending->firstBefore   = state.walletShadow;
+        pending->semantic      = state.shop.semantic;
+        const auto index       = PChar->Container->getExSize();
+        const auto itemId      = PChar->Container->getItemID(index);
+        const auto quantity    = PChar->Container->getQuantity(index);
+        if (itemId > 0 && quantity > 0)
+        {
+            pending->semantic.itemId.set(itemId);
+            pending->semantic.itemQuantity.set(quantity);
+            const auto slotId = PChar->Container->getInvSlotID(index);
+            if (const auto* inventory = PChar->getStorage(LOC_INVENTORY))
+            {
+                if (const auto* item = inventory->GetItem(slotId); item && item->getID() == itemId)
+                {
+                    pending->expectedBaseAmount = static_cast<std::uint32_t>(quantity * item->getBasePrice());
+                }
+            }
+        }
+    }
+
+    void stageAuctionListing(CharacterState& state, CCharEntity* PChar, const GP_CLI_COMMAND_AUC& packet)
+    {
+        auto* pending = allocatePending(state, NativeOperation::AuctionListing);
+        if (!pending)
+        {
+            return;
+        }
+        pending->transactionId = globalProducer().nextTransactionId("ah-list");
+        pending->firstCharId   = state.charId;
+        pending->firstBefore   = state.walletShadow;
+        pending->semantic      = systemContext("auction-house");
+        pending->semantic.zoneId.set(PChar->getZone());
+
+        if (const auto* inventory = PChar->getStorage(LOC_INVENTORY);
+            inventory && packet.Param.LotIn.ItemWorkIndex <= std::numeric_limits<uint8>::max())
+        {
+            if (const auto* item = inventory->GetItem(static_cast<uint8>(packet.Param.LotIn.ItemWorkIndex)); item)
+            {
+                pending->semantic.itemId.set(item->getID());
+                pending->semantic.itemQuantity.set(packet.Param.LotIn.ItemStacks == 0 ? item->getStackSize() : 1);
+            }
+        }
+    }
+
+    void stageBazaar(CharacterState& buyerState, CCharEntity* PBuyer, const GP_CLI_COMMAND_BAZAAR_BUY& packet)
+    {
+        auto* PSeller = static_cast<CCharEntity*>(PBuyer->GetEntity(PBuyer->BazaarID.targid, TYPE_PC));
+        if (!PSeller || PSeller->id != PBuyer->BazaarID.id)
+        {
+            return;
+        }
+        auto* sellerState = ensureState(PSeller);
+        if (!sellerState)
+        {
+            return;
+        }
+        synchronizeShadow(*sellerState, PSeller, "bazaar-peer-shadow-desync");
+
+        std::uint16_t itemId{};
+        std::uint64_t baseAmount{};
+        if (const auto* inventory = PSeller->getStorage(LOC_INVENTORY))
+        {
+            if (const auto* item = inventory->GetItem(packet.BazaarItemIndex); item)
+            {
+                itemId     = item->getID();
+                baseAmount = static_cast<std::uint64_t>(item->getCharPrice()) * packet.BuyNum;
+            }
+        }
+        if (baseAmount == 0)
+        {
+            return;
+        }
+
+        auto* buyerPending  = allocatePending(buyerState, NativeOperation::Bazaar);
+        auto* sellerPending = allocatePending(*sellerState, NativeOperation::Bazaar);
+        if (!buyerPending || !sellerPending)
+        {
+            if (buyerPending)
+            {
+                *buyerPending = {};
+            }
+            if (sellerPending)
+            {
+                *sellerPending = {};
+            }
+            buyerState.pendingOverflow   = true;
+            sellerState->pendingOverflow = true;
+            return;
+        }
+
+        const auto transactionId = globalProducer().nextTransactionId("bazaar");
+        const auto deadline      = SteadyClock::now() + NativeDeadline;
+        auto       semantic      = systemContext("bazaar");
+        semantic.zoneId.set(PBuyer->getZone());
+        if (itemId > 0)
+        {
+            semantic.itemId.set(itemId);
+            semantic.itemQuantity.set(packet.BuyNum);
+        }
+
+        *buyerPending                     = makePairPending(NativeOperation::Bazaar,
+                                                            PairRole::First,
+                                                            transactionId,
+                                                            deadline,
+                                                            semantic,
+                                                            PBuyer->id,
+                                                            PSeller->id,
+                                                            buyerState.walletShadow,
+                                                            sellerState->walletShadow);
+        *sellerPending                    = *buyerPending;
+        sellerPending->role               = PairRole::Second;
+        sellerPending->beforeGil          = sellerState->walletShadow;
+        sellerPending->latestGil          = sellerState->walletShadow;
+        buyerPending->expectedBaseAmount  = baseAmount;
+        sellerPending->expectedBaseAmount = baseAmount;
+    }
+
+    void stageTrade(CharacterState& firstState, CCharEntity* PFirst, const GP_CLI_COMMAND_TRADE_RES& packet)
+    {
+        if (static_cast<GP_CLI_COMMAND_TRADE_RES_KIND>(packet.Kind) != GP_CLI_COMMAND_TRADE_RES_KIND::Make)
+        {
+            return;
+        }
+        auto* PSecond = static_cast<CCharEntity*>(PFirst->GetEntity(PFirst->TradePending.targid, TYPE_PC));
+        if (!PSecond || !PSecond->UContainer || !PSecond->UContainer->IsLocked() ||
+            PFirst->TradePending.id != PSecond->id || PSecond->TradePending.id != PFirst->id)
+        {
+            return;
+        }
+        auto* secondState = ensureState(PSecond);
+        if (!secondState)
+        {
+            return;
+        }
+        synchronizeShadow(*secondState, PSecond, "trade-peer-shadow-desync");
+
+        auto* firstPending  = allocatePending(firstState, NativeOperation::PlayerTrade);
+        auto* secondPending = allocatePending(*secondState, NativeOperation::PlayerTrade);
+        if (!firstPending || !secondPending)
+        {
+            if (firstPending)
+            {
+                *firstPending = {};
+            }
+            if (secondPending)
+            {
+                *secondPending = {};
+            }
+            firstState.pendingOverflow   = true;
+            secondState->pendingOverflow = true;
+            return;
+        }
+
+        const auto transactionId = globalProducer().nextTransactionId("trade");
+        const auto deadline      = SteadyClock::now() + NativeDeadline;
+        auto       semantic      = systemContext("player-trade");
+        semantic.zoneId.set(PFirst->getZone());
+        *firstPending             = makePairPending(NativeOperation::PlayerTrade,
+                                                    PairRole::First,
+                                                    transactionId,
+                                                    deadline,
+                                                    semantic,
+                                                    PFirst->id,
+                                                    PSecond->id,
+                                                    firstState.walletShadow,
+                                                    secondState->walletShadow);
+        firstPending->firstOffer  = offeredGil(PFirst);
+        firstPending->secondOffer = offeredGil(PSecond);
+        *secondPending            = *firstPending;
+        secondPending->role       = PairRole::Second;
+        secondPending->beforeGil  = secondState->walletShadow;
+        secondPending->latestGil  = secondState->walletShadow;
+    }
+
+    [[nodiscard]] static auto makePairPending(NativeOperation         operation,
+                                              PairRole                role,
+                                              const TransactionId&    transactionId,
+                                              SteadyClock::time_point deadline,
+                                              const SemanticContext&  semantic,
+                                              std::uint32_t           firstId,
+                                              std::uint32_t           secondId,
+                                              std::uint64_t           firstBefore,
+                                              std::uint64_t           secondBefore) -> PendingOperation
+    {
+        PendingOperation pending;
+        pending.active        = true;
+        pending.operation     = operation;
+        pending.role          = role;
+        pending.transactionId = transactionId;
+        pending.deadline      = deadline;
+        pending.semantic      = semantic;
+        pending.firstCharId   = firstId;
+        pending.secondCharId  = secondId;
+        pending.firstBefore   = firstBefore;
+        pending.secondBefore  = secondBefore;
+        pending.beforeGil     = role == PairRole::First ? firstBefore : secondBefore;
+        pending.latestGil     = pending.beforeGil;
+        return pending;
+    }
+
+    std::array<CharacterState, MaxTrackedCharacters> characters_{};
+    SteadyClock::time_point                          nextExpirySweep_{};
+};
+
+REGISTER_CPP_MODULE(EconomyTelemetryModule);

--- a/modules/phoenix/economy/cpp/economy_producer.cpp
+++ b/modules/phoenix/economy/cpp/economy_producer.cpp
@@ -1,0 +1,1816 @@
+#include "economy_producer.h"
+
+#include <concurrentqueue.h>
+#include <openssl/rand.h>
+#include <openssl/sha.h>
+#include <zlib.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cctype>
+#include <charconv>
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <filesystem>
+#include <limits>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <Windows.h>
+#else
+#include <cerrno>
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+namespace phoenix::economy
+{
+namespace
+{
+
+using SteadyClock = std::chrono::steady_clock;
+
+constexpr std::size_t   MaxUncompressedBatchBytes = 1024 * 1024;
+constexpr std::uint64_t MinHardCapBytes           = 4096;
+constexpr std::uint64_t MinControlReserveBytes    = 1024;
+constexpr std::size_t   MaxQueueCapacity          = 1024 * 1024;
+constexpr auto          WorkerPollInterval        = std::chrono::milliseconds(10);
+
+#ifdef PHOENIX_ECONOMY_TESTING
+thread_local std::uint64_t recordQueueAllocationCalls{};
+#endif
+
+struct RecordQueueTraits : moodycamel::ConcurrentQueueDefaultTraits
+{
+    // Tokenless production is deliberately unavailable. This both enforces the
+    // one-map-thread design and avoids an implicit producer's first-use allocation.
+    static constexpr std::size_t INITIAL_IMPLICIT_PRODUCER_HASH_SIZE = 0;
+
+    static auto malloc(std::size_t size) -> void*
+    {
+#ifdef PHOENIX_ECONOMY_TESTING
+        ++recordQueueAllocationCalls;
+#endif
+        return std::malloc(size);
+    }
+
+    static void free(void* pointer)
+    {
+        std::free(pointer);
+    }
+};
+
+enum class RunState : std::uint8_t
+{
+    Disabled,
+    Running,
+    Stopping,
+};
+
+enum class ErrorCode : std::uint8_t
+{
+    None,
+    InvalidConfiguration,
+    WorkerStartFailed,
+    SpoolDirectoryFailure,
+    SerializeFailure,
+    CompressFailure,
+    SpoolCapacity,
+    SpoolWriteFailure,
+};
+
+enum class GapReason : std::uint8_t
+{
+    QueueOverflow,
+    SpoolCapacity,
+    SpoolWriteFailure,
+    SequenceDiscontinuity,
+};
+
+enum class PersistResult : std::uint8_t
+{
+    Written,
+    Capacity,
+    Failed,
+};
+
+enum class DurableWriteResult : std::uint8_t
+{
+    Durable,
+    VisibleDirectorySyncUncertain,
+    Failed,
+};
+
+struct Gap
+{
+    bool          active{};
+    GapReason     reason{};
+    std::int64_t  startUnixNanos{};
+    std::int64_t  endUnixNanos{};
+    std::uint64_t lostEventCount{};
+    std::uint64_t ordinal{};
+};
+
+enum class RecordType : std::uint8_t
+{
+    Event,
+    AttributionGap,
+    ForgoneMint,
+};
+
+constexpr auto MaxRecordPayloadSize = sizeof(Event) > sizeof(AttributionGap) ? (sizeof(Event) > sizeof(ForgoneMint) ? sizeof(Event) : sizeof(ForgoneMint)) : (sizeof(AttributionGap) > sizeof(ForgoneMint) ? sizeof(AttributionGap) : sizeof(ForgoneMint));
+
+struct QueuedRecord
+{
+    RecordType                                  type;
+    std::array<std::byte, MaxRecordPayloadSize> payload;
+
+    template <typename T>
+    [[nodiscard]] static auto from(RecordType recordType, const T& value) noexcept -> QueuedRecord
+    {
+        static_assert(std::is_trivially_copyable_v<T>);
+        QueuedRecord record;
+        record.type = recordType;
+        std::memcpy(record.payload.data(), &value, sizeof(T));
+        return record;
+    }
+
+    template <typename T>
+    [[nodiscard]] auto as() const noexcept -> T
+    {
+        static_assert(std::is_trivially_copyable_v<T>);
+        T value;
+        std::memcpy(&value, payload.data(), sizeof(T));
+        return value;
+    }
+};
+
+struct BatchCounts
+{
+    std::size_t events{};
+    std::size_t attributionGaps{};
+    std::size_t forgoneMints{};
+
+    [[nodiscard]] auto controls() const noexcept -> std::size_t
+    {
+        return attributionGaps + forgoneMints;
+    }
+
+    [[nodiscard]] auto total() const noexcept -> std::size_t
+    {
+        return events + controls();
+    }
+};
+
+static_assert(std::is_trivially_copyable_v<QueuedRecord>);
+
+auto gapReasonName(GapReason reason) noexcept -> std::string_view
+{
+    switch (reason)
+    {
+        case GapReason::QueueOverflow:
+            return "queue_overflow";
+        case GapReason::SpoolCapacity:
+            return "spool_capacity";
+        case GapReason::SpoolWriteFailure:
+            return "spool_write_failure";
+        case GapReason::SequenceDiscontinuity:
+            return "sequence_discontinuity";
+    }
+    return "spool_write_failure";
+}
+
+auto kindName(Kind kind) noexcept -> std::string_view
+{
+    switch (kind)
+    {
+        case Kind::Mint:
+            return "mint";
+        case Kind::Burn:
+            return "burn";
+        case Kind::Transfer:
+            return "transfer";
+    }
+    return "mint";
+}
+
+auto categoryName(Category category) noexcept -> std::string_view
+{
+    switch (category)
+    {
+        case Category::MobDrop:
+            return "mob_drop";
+        case Category::Mug:
+            return "mug";
+        case Category::NpcVendorSale:
+            return "npc_vendor_sale";
+        case Category::GuildVendorSale:
+            return "guild_vendor_sale";
+        case Category::QuestReward:
+            return "quest_reward";
+        case Category::MissionReward:
+            return "mission_reward";
+        case Category::BattlefieldReward:
+            return "battlefield_reward";
+        case Category::RegimeReward:
+            return "regime_reward";
+        case Category::StartingGil:
+            return "starting_gil";
+        case Category::AdminGrant:
+            return "admin_grant";
+        case Category::ScriptReward:
+            return "script_reward";
+        case Category::OtherMint:
+            return "other_mint";
+        case Category::NpcShopPurchase:
+            return "npc_shop_purchase";
+        case Category::GuildShopPurchase:
+            return "guild_shop_purchase";
+        case Category::AuctionListingFee:
+            return "auction_listing_fee";
+        case Category::BazaarTax:
+            return "bazaar_tax";
+        case Category::ChocoboRental:
+            return "chocobo_rental";
+        case Category::TransportFee:
+            return "transport_fee";
+        case Category::QuestFee:
+            return "quest_fee";
+        case Category::ServiceFee:
+            return "service_fee";
+        case Category::CurrencyCapLoss:
+            return "currency_cap_loss";
+        case Category::AdminRemove:
+            return "admin_remove";
+        case Category::OtherBurn:
+            return "other_burn";
+        case Category::PlayerTrade:
+            return "player_trade";
+        case Category::BazaarSale:
+            return "bazaar_sale";
+        case Category::AuctionSale:
+            return "auction_sale";
+        case Category::DeliveryBox:
+            return "delivery_box";
+        case Category::OtherTransfer:
+            return "other_transfer";
+    }
+    return "other_mint";
+}
+
+auto sourceTypeName(SourceType sourceType) noexcept -> std::string_view
+{
+    switch (sourceType)
+    {
+        case SourceType::Mob:
+            return "mob";
+        case SourceType::Npc:
+            return "npc";
+        case SourceType::Quest:
+            return "quest";
+        case SourceType::Mission:
+            return "mission";
+        case SourceType::Battlefield:
+            return "battlefield";
+        case SourceType::Regime:
+            return "regime";
+        case SourceType::Admin:
+            return "admin";
+        case SourceType::Script:
+            return "script";
+        case SourceType::System:
+            return "system";
+    }
+    return "system";
+}
+
+auto attributionQualityName(AttributionQuality quality) noexcept -> std::string_view
+{
+    return quality == AttributionQuality::Semantic ? "semantic" : "correlated";
+}
+
+auto attributionDirectionName(AttributionDirection direction) noexcept -> std::string_view
+{
+    return direction == AttributionDirection::Credit ? "credit" : "debit";
+}
+
+auto evidenceTypeName(EvidenceType evidenceType) noexcept -> std::string_view
+{
+    switch (evidenceType)
+    {
+        case EvidenceType::LuaWallet:
+            return "lua_wallet";
+        case EvidenceType::WalletObserver:
+            return "wallet_observer";
+        case EvidenceType::PacketCorrelator:
+            return "packet_correlator";
+        case EvidenceType::NativePacket:
+            return "native_packet";
+        case EvidenceType::TransferReconciliation:
+            return "transfer_reconciliation";
+    }
+    return "wallet_observer";
+}
+
+void appendQuoted(std::string& output, std::string_view value)
+{
+    output.push_back('"');
+    output.append(value);
+    output.push_back('"');
+}
+
+template <typename T>
+void appendNumber(std::string& output, T value)
+{
+    std::array<char, std::numeric_limits<T>::digits10 + 4> buffer{};
+    const auto                                             result = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value);
+    output.append(buffer.data(), result.ptr);
+}
+
+template <typename T>
+void appendDecimalString(std::string& output, T value)
+{
+    output.push_back('"');
+    appendNumber(output, value);
+    output.push_back('"');
+}
+
+template <typename T>
+void appendNullableNumber(std::string& output, const Nullable<T>& value)
+{
+    if (value.hasValue)
+    {
+        appendNumber(output, value.value);
+    }
+    else
+    {
+        output.append("null");
+    }
+}
+
+auto timestamp(std::int64_t unixNanos) -> std::string
+{
+    const auto unixMillis = unixNanos / 1000000;
+    const auto seconds    = static_cast<std::time_t>(unixMillis / 1000);
+    const auto millis     = static_cast<unsigned>(unixMillis % 1000);
+    std::tm    utc{};
+#ifdef _WIN32
+    gmtime_s(&utc, &seconds);
+#else
+    gmtime_r(&seconds, &utc);
+#endif
+
+    std::array<char, 32> buffer{};
+    const auto           count = std::snprintf(buffer.data(), buffer.size(), "%04d-%02d-%02dT%02d:%02d:%02d.%03uZ", utc.tm_year + 1900, utc.tm_mon + 1, utc.tm_mday, utc.tm_hour, utc.tm_min, utc.tm_sec, millis);
+    return { buffer.data(), static_cast<std::size_t>(count) };
+}
+
+void appendContext(std::string& output, SourceType sourceType, const SourceContext& context)
+{
+    output.push_back('{');
+    auto needsComma = false;
+    auto numeric    = [&](std::string_view key, const auto& value)
+    {
+        if (!value.hasValue)
+        {
+            return;
+        }
+        if (needsComma)
+        {
+            output.push_back(',');
+        }
+        appendQuoted(output, key);
+        output.push_back(':');
+        appendNumber(output, value.value);
+        needsComma = true;
+    };
+    auto token = [&](std::string_view key, std::string_view value)
+    {
+        if (value.empty())
+        {
+            return;
+        }
+        if (needsComma)
+        {
+            output.push_back(',');
+        }
+        appendQuoted(output, key);
+        output.push_back(':');
+        appendQuoted(output, value);
+        needsComma = true;
+    };
+
+    // Every per-source key is emitted in lexicographic order.
+    switch (sourceType)
+    {
+        case SourceType::Mob:
+            numeric("mobPoolId", context.mobPoolId);
+            numeric("mobSpawnId", context.mobSpawnId);
+            break;
+        case SourceType::Npc:
+            numeric("guildId", context.guildId);
+            numeric("npcId", context.npcId);
+            token("serviceKey", context.serviceKey.view());
+            numeric("shopId", context.shopId);
+            break;
+        case SourceType::Quest:
+            numeric("questId", context.questId);
+            numeric("questLogId", context.questLogId);
+            break;
+        case SourceType::Mission:
+            numeric("missionId", context.missionId);
+            numeric("missionLogId", context.missionLogId);
+            break;
+        case SourceType::Battlefield:
+            numeric("battlefieldId", context.battlefieldId);
+            break;
+        case SourceType::Regime:
+            numeric("regimeId", context.regimeId);
+            break;
+        case SourceType::Admin:
+            numeric("actorCharId", context.actorCharId);
+            break;
+        case SourceType::Script:
+            token("scriptKey", context.scriptKey.view());
+            break;
+        case SourceType::System:
+            token("systemKey", context.systemKey.view());
+            break;
+    }
+    output.push_back('}');
+}
+
+void appendEvent(std::string& output, const Event& event)
+{
+    output.append("{\"amount\":");
+    appendDecimalString(output, event.amount);
+    output.append(",\"attributionQuality\":");
+    appendQuoted(output, attributionQualityName(event.attributionQuality));
+    output.append(",\"categoryKey\":");
+    appendQuoted(output, categoryName(event.category));
+    output.append(",\"contentVersion\":");
+    appendQuoted(output, event.contentVersion.view());
+    output.append(",\"context\":");
+    appendContext(output, event.sourceType, event.context);
+    output.append(",\"eventSeq\":");
+    appendDecimalString(output, event.eventSeq);
+    output.append(",\"evidenceVersion\":");
+    appendQuoted(output, event.evidenceVersion.view());
+    output.append(",\"fromCharId\":");
+    appendNullableNumber(output, event.fromCharId);
+    output.append(",\"itemId\":");
+    appendNullableNumber(output, event.itemId);
+    output.append(",\"itemQuantity\":");
+    appendNullableNumber(output, event.itemQuantity);
+    output.append(",\"kind\":");
+    appendQuoted(output, kindName(event.kind));
+    output.append(",\"occurredAt\":");
+    appendQuoted(output, timestamp(event.occurredAtUnixNanos));
+    output.append(",\"sourceKey\":");
+    appendQuoted(output, event.sourceKey.view());
+    output.append(",\"sourceType\":");
+    appendQuoted(output, sourceTypeName(event.sourceType));
+    output.append(",\"toCharId\":");
+    appendNullableNumber(output, event.toCharId);
+    output.append(",\"transactionId\":");
+    appendQuoted(output, event.transactionId.view());
+    output.append(",\"zoneId\":");
+    appendNullableNumber(output, event.zoneId);
+    output.push_back('}');
+}
+
+void appendAttributionGap(std::string& output, const AttributionGap& gap)
+{
+    output.append("{\"appliedDelta\":");
+    appendDecimalString(output, gap.appliedDelta);
+    output.append(",\"charId\":");
+    appendNumber(output, gap.charId);
+    output.append(",\"contentVersion\":");
+    appendQuoted(output, gap.contentVersion.view());
+    output.append(",\"controlSeq\":");
+    appendDecimalString(output, gap.controlSeq);
+    output.append(",\"detailCode\":");
+    appendQuoted(output, gap.detailCode.view());
+    output.append(",\"direction\":");
+    appendQuoted(output, attributionDirectionName(gap.direction));
+    output.append(",\"evidenceType\":");
+    appendQuoted(output, evidenceTypeName(gap.evidenceType));
+    output.append(",\"evidenceVersion\":");
+    appendQuoted(output, gap.evidenceVersion.view());
+    output.append(",\"occurredAt\":");
+    appendQuoted(output, timestamp(gap.occurredAtUnixNanos));
+    output.append(",\"sourceHint\":");
+    if (gap.sourceHint.empty())
+    {
+        output.append("null");
+    }
+    else
+    {
+        appendQuoted(output, gap.sourceHint.view());
+    }
+    output.append(",\"zoneId\":");
+    appendNullableNumber(output, gap.zoneId);
+    output.push_back('}');
+}
+
+void appendForgoneMint(std::string& output, const ForgoneMint& diagnostic)
+{
+    output.append("{\"appliedAmount\":");
+    appendDecimalString(output, diagnostic.appliedAmount);
+    output.append(",\"attributionQuality\":");
+    appendQuoted(output, attributionQualityName(diagnostic.attributionQuality));
+    output.append(",\"categoryKey\":");
+    appendQuoted(output, categoryName(diagnostic.category));
+    output.append(",\"charId\":");
+    appendNumber(output, diagnostic.charId);
+    output.append(",\"contentVersion\":");
+    appendQuoted(output, diagnostic.contentVersion.view());
+    output.append(",\"context\":");
+    appendContext(output, diagnostic.sourceType, diagnostic.context);
+    output.append(",\"controlSeq\":");
+    appendDecimalString(output, diagnostic.controlSeq);
+    output.append(",\"evidenceVersion\":");
+    appendQuoted(output, diagnostic.evidenceVersion.view());
+    output.append(",\"forgoneAmount\":");
+    appendDecimalString(output, diagnostic.forgoneAmount);
+    output.append(",\"occurredAt\":");
+    appendQuoted(output, timestamp(diagnostic.occurredAtUnixNanos));
+    output.append(",\"requestedAmount\":");
+    appendDecimalString(output, diagnostic.requestedAmount);
+    output.append(",\"sourceKey\":");
+    appendQuoted(output, diagnostic.sourceKey.view());
+    output.append(",\"sourceType\":");
+    appendQuoted(output, sourceTypeName(diagnostic.sourceType));
+    output.append(",\"transactionId\":");
+    appendQuoted(output, diagnostic.transactionId.view());
+    output.append(",\"zoneId\":");
+    appendNullableNumber(output, diagnostic.zoneId);
+    output.push_back('}');
+}
+
+auto sha256(std::string_view input) -> std::string
+{
+    std::array<unsigned char, SHA256_DIGEST_LENGTH> digest{};
+    SHA256(reinterpret_cast<const unsigned char*>(input.data()), input.size(), digest.data());
+
+    constexpr std::string_view Hex = "0123456789abcdef";
+    std::string                output;
+    output.resize(SHA256_DIGEST_LENGTH * 2);
+    for (std::size_t index = 0; index < digest.size(); ++index)
+    {
+        output[index * 2]     = Hex[digest[index] >> 4U];
+        output[index * 2 + 1] = Hex[digest[index] & 0x0FU];
+    }
+    return output;
+}
+
+auto compressGzip(std::string_view input, std::vector<unsigned char>& output) -> bool
+{
+    z_stream stream{};
+    if (deflateInit2(&stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED, MAX_WBITS + 16, 8, Z_DEFAULT_STRATEGY) != Z_OK)
+    {
+        return false;
+    }
+
+    output.resize(deflateBound(&stream, static_cast<uLong>(input.size())));
+    stream.next_in    = reinterpret_cast<Bytef*>(const_cast<char*>(input.data()));
+    stream.avail_in   = static_cast<uInt>(input.size());
+    stream.next_out   = output.data();
+    stream.avail_out  = static_cast<uInt>(output.size());
+    const auto result = deflate(&stream, Z_FINISH);
+    if (result != Z_STREAM_END)
+    {
+        deflateEnd(&stream);
+        output.clear();
+        return false;
+    }
+
+    output.resize(stream.total_out);
+    return deflateEnd(&stream) == Z_OK;
+}
+
+auto truthy(const char* value) noexcept -> bool
+{
+    if (value == nullptr)
+    {
+        return false;
+    }
+
+    std::string normalized(value);
+    std::transform(normalized.begin(), normalized.end(), normalized.begin(), [](unsigned char character)
+                   {
+                       return static_cast<char>(std::tolower(character));
+                   });
+    return normalized == "1" || normalized == "true" || normalized == "yes" || normalized == "on";
+}
+
+template <typename T>
+auto parseUnsignedEnvironment(const char* name, T fallback) noexcept -> T
+{
+    const auto* value = std::getenv(name);
+    if (value == nullptr || *value == '\0')
+    {
+        return fallback;
+    }
+
+    std::uint64_t parsed{};
+    const auto    length = std::strlen(value);
+    const auto    result = std::from_chars(value, value + length, parsed);
+    if (result.ec != std::errc{} || result.ptr != value + length || parsed > std::numeric_limits<T>::max())
+    {
+        return fallback;
+    }
+    return static_cast<T>(parsed);
+}
+
+template <std::size_t Capacity>
+void assignEnvironment(FixedString<Capacity>& output, const char* name, std::string_view fallback = {}) noexcept
+{
+    const auto* value = std::getenv(name);
+    if (value != nullptr && *value != '\0')
+    {
+        static_cast<void>(output.assign(value));
+    }
+    else if (!fallback.empty())
+    {
+        static_cast<void>(output.assign(fallback));
+    }
+}
+
+auto generateBootId() noexcept -> FixedString<36>
+{
+    std::array<unsigned char, 16> random{};
+    if (RAND_bytes(random.data(), static_cast<int>(random.size())) != 1)
+    {
+        auto seed = static_cast<std::uint64_t>(unixNanosNow());
+        for (auto& value : random)
+        {
+            seed ^= seed << 13U;
+            seed ^= seed >> 7U;
+            seed ^= seed << 17U;
+            value = static_cast<unsigned char>(seed & 0xFFU);
+        }
+    }
+    random[6] = static_cast<unsigned char>((random[6] & 0x0FU) | 0x40U);
+    random[8] = static_cast<unsigned char>((random[8] & 0x3FU) | 0x80U);
+
+    constexpr std::string_view Hex = "0123456789abcdef";
+    std::array<char, 37>       formatted{};
+    std::size_t                outputIndex{};
+    for (std::size_t index = 0; index < random.size(); ++index)
+    {
+        if (index == 4 || index == 6 || index == 8 || index == 10)
+        {
+            formatted[outputIndex++] = '-';
+        }
+        formatted[outputIndex++] = Hex[random[index] >> 4U];
+        formatted[outputIndex++] = Hex[random[index] & 0x0FU];
+    }
+
+    FixedString<36> bootId;
+    static_cast<void>(bootId.assign({ formatted.data(), 36 }));
+    return bootId;
+}
+
+auto spoolBytes(const std::filesystem::path& directory) noexcept -> std::uint64_t
+{
+    std::error_code                           error;
+    std::uint64_t                             total{};
+    std::filesystem::directory_iterator       iterator(directory, error);
+    const std::filesystem::directory_iterator end;
+    while (!error && iterator != end)
+    {
+        const auto status = iterator->symlink_status(error);
+        if (!error && std::filesystem::is_regular_file(status))
+        {
+            const auto size = iterator->file_size(error);
+            if (!error && size <= std::numeric_limits<std::uint64_t>::max() - total)
+            {
+                total += size;
+            }
+        }
+        iterator.increment(error);
+    }
+    return total;
+}
+
+#ifdef _WIN32
+auto writeDurableFile(const std::filesystem::path& temporary, const std::filesystem::path& completed, const std::vector<unsigned char>& contents) noexcept -> DurableWriteResult
+{
+    const auto handle = CreateFileW(temporary.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (handle == INVALID_HANDLE_VALUE)
+    {
+        return DurableWriteResult::Failed;
+    }
+
+    auto        success = true;
+    std::size_t offset{};
+    while (offset < contents.size())
+    {
+        const auto remaining = std::min<std::size_t>(contents.size() - offset, std::numeric_limits<DWORD>::max());
+        DWORD      written{};
+        if (WriteFile(handle, contents.data() + offset, static_cast<DWORD>(remaining), &written, nullptr) == FALSE || written == 0)
+        {
+            success = false;
+            break;
+        }
+        offset += written;
+    }
+    if (success && FlushFileBuffers(handle) == FALSE)
+    {
+        success = false;
+    }
+    if (CloseHandle(handle) == FALSE)
+    {
+        success = false;
+    }
+    if (success && MoveFileExW(temporary.c_str(), completed.c_str(), MOVEFILE_WRITE_THROUGH) == FALSE)
+    {
+        success = false;
+    }
+    if (!success)
+    {
+        std::error_code ignored;
+        std::filesystem::remove(temporary, ignored);
+    }
+    return success ? DurableWriteResult::Durable : DurableWriteResult::Failed;
+}
+#else
+auto writeDurableFile(const std::filesystem::path& temporary, const std::filesystem::path& completed, const std::vector<unsigned char>& contents) noexcept -> DurableWriteResult
+{
+    const auto descriptor = ::open(temporary.c_str(), O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC, 0640);
+    if (descriptor < 0)
+    {
+        return DurableWriteResult::Failed;
+    }
+
+    auto        success = true;
+    std::size_t offset{};
+    while (offset < contents.size())
+    {
+        const auto written = ::write(descriptor, contents.data() + offset, contents.size() - offset);
+        if (written < 0 && errno == EINTR)
+        {
+            continue;
+        }
+        if (written <= 0)
+        {
+            success = false;
+            break;
+        }
+        offset += static_cast<std::size_t>(written);
+    }
+    if (success && ::fsync(descriptor) != 0)
+    {
+        success = false;
+    }
+    if (::close(descriptor) != 0)
+    {
+        success = false;
+    }
+    if (success)
+    {
+        std::error_code error;
+        std::filesystem::rename(temporary, completed, error);
+        success = !error;
+    }
+    auto directorySynced = false;
+    if (success)
+    {
+        const auto directoryDescriptor = ::open(completed.parent_path().c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+        if (directoryDescriptor >= 0 && ::fsync(directoryDescriptor) == 0)
+        {
+            directorySynced = true;
+        }
+        if (directoryDescriptor >= 0)
+        {
+            ::close(directoryDescriptor);
+        }
+    }
+    if (!success)
+    {
+        std::error_code ignored;
+        std::filesystem::remove(temporary, ignored);
+    }
+    if (!success)
+    {
+        return DurableWriteResult::Failed;
+    }
+    return directorySynced ? DurableWriteResult::Durable : DurableWriteResult::VisibleDirectorySyncUncertain;
+}
+#endif
+
+} // namespace
+
+struct Producer::Impl
+{
+    using RecordQueue = moodycamel::ConcurrentQueue<QueuedRecord, RecordQueueTraits>;
+
+    ProducerConfig                             config;
+    std::unique_ptr<RecordQueue>               queue;
+    std::unique_ptr<moodycamel::ProducerToken> producerToken;
+    std::thread::id                            producerThreadId{};
+    FixedString<36>                            bootId;
+
+    std::atomic<RunState>   state{ RunState::Disabled };
+    std::atomic<bool>       stopRequested{};
+    std::thread             worker;
+    std::mutex              wakeMutex;
+    std::condition_variable wakeCondition;
+
+    std::atomic<std::uint64_t> transactionOrdinal{};
+    std::atomic<std::uint64_t> enqueuedEvents{};
+    std::atomic<std::uint64_t> droppedEvents{};
+    std::atomic<std::uint64_t> queueOverflowEvents{};
+    std::atomic<std::uint64_t> producerThreadViolationEvents{};
+    std::atomic<std::uint64_t> invalidEvents{};
+    std::atomic<std::uint64_t> spoolCapacityEvents{};
+    std::atomic<std::uint64_t> spoolWriteFailureEvents{};
+    std::atomic<std::uint64_t> batchesWritten{};
+    std::atomic<std::uint64_t> reportedSpoolBytes{};
+
+    std::atomic<std::uint64_t> unreportedQueueDrops{};
+    std::atomic<std::int64_t>  queueDropStartUnixNanos{};
+    std::atomic<std::int64_t>  queueDropEndUnixNanos{};
+    std::atomic<std::uint64_t> unreportedProducerThreadDrops{};
+    std::atomic<std::int64_t>  producerThreadDropStartUnixNanos{};
+    std::atomic<std::int64_t>  producerThreadDropEndUnixNanos{};
+    std::atomic<std::uint64_t> gameTickSequence{};
+    std::atomic<std::int64_t>  latestGameTickUnixNanos{};
+    std::atomic<ErrorCode>     lastError{ ErrorCode::None };
+
+    std::array<Gap, 4>      pendingGaps{};
+    std::uint64_t           nextGapOrdinal{ 1 };
+    std::uint64_t           nextBatchSequence{ 1 };
+    std::uint64_t           nextEventSequence{ 1 };
+    std::uint64_t           nextControlSequence{ 1 };
+    std::uint64_t           lastDurableGameTickSequence{};
+    std::int64_t            lastWatermarkUnixMillis{};
+    SteadyClock::time_point lastDurableWrite{};
+    SteadyClock::time_point retryPersistenceAfter{};
+    PersistResult           lastPersistFailure{ PersistResult::Failed };
+    std::int64_t            bootStartedUnixMillis{};
+
+    auto enqueue(QueuedRecord record, std::int64_t lossTime) noexcept -> RecordResult
+    {
+        if (state.load(std::memory_order_acquire) != RunState::Running)
+        {
+            return RecordResult::Disabled;
+        }
+        if (std::this_thread::get_id() != producerThreadId)
+        {
+            const auto occurredAt = lossTime > 0 ? lossTime : unixNanosNow();
+            droppedEvents.fetch_add(1, std::memory_order_relaxed);
+            invalidEvents.fetch_add(1, std::memory_order_relaxed);
+            producerThreadViolationEvents.fetch_add(1, std::memory_order_relaxed);
+            unreportedProducerThreadDrops.fetch_add(1, std::memory_order_relaxed);
+            auto noStart = std::int64_t{};
+            producerThreadDropStartUnixNanos.compare_exchange_strong(
+                noStart, occurredAt, std::memory_order_relaxed);
+            producerThreadDropEndUnixNanos.store(occurredAt, std::memory_order_release);
+            return RecordResult::InvalidEvent;
+        }
+        if (!queue->try_enqueue(*producerToken, record))
+        {
+            droppedEvents.fetch_add(1, std::memory_order_relaxed);
+            queueOverflowEvents.fetch_add(1, std::memory_order_relaxed);
+            unreportedQueueDrops.fetch_add(1, std::memory_order_relaxed);
+            auto noStart = std::int64_t{};
+            queueDropStartUnixNanos.compare_exchange_strong(noStart, lossTime, std::memory_order_relaxed);
+            queueDropEndUnixNanos.store(lossTime, std::memory_order_release);
+            return RecordResult::QueueFull;
+        }
+        enqueuedEvents.fetch_add(1, std::memory_order_relaxed);
+        return RecordResult::Enqueued;
+    }
+
+    void mergeGap(GapReason reason, std::int64_t start, std::int64_t end, std::uint64_t count) noexcept
+    {
+        constexpr auto MaxFutureSkewNanos = 5LL * 60LL * 1000000000LL;
+        const auto     now                = unixNanosNow();
+        if (start <= 0 || start > now + MaxFutureSkewNanos)
+        {
+            start = now;
+        }
+        if (end <= 0 || end > now + MaxFutureSkewNanos)
+        {
+            end = now;
+        }
+        if (end < start)
+        {
+            end = start;
+        }
+
+        auto& gap = pendingGaps[static_cast<std::size_t>(reason)];
+        if (!gap.active)
+        {
+            gap.active         = true;
+            gap.reason         = reason;
+            gap.startUnixNanos = start;
+            gap.endUnixNanos   = end;
+            gap.ordinal        = nextGapOrdinal++;
+        }
+        else
+        {
+            gap.startUnixNanos = std::min(gap.startUnixNanos, start);
+            gap.endUnixNanos   = std::max(gap.endUnixNanos, end);
+        }
+        gap.lostEventCount += count;
+    }
+
+    void collectQueueGap() noexcept
+    {
+        const auto start = queueDropStartUnixNanos.exchange(0, std::memory_order_acq_rel);
+        const auto count = unreportedQueueDrops.exchange(0, std::memory_order_acq_rel);
+        const auto end   = queueDropEndUnixNanos.load(std::memory_order_acquire);
+        if (count > 0)
+        {
+            const auto fallback = unixNanosNow();
+            mergeGap(GapReason::QueueOverflow, start > 0 ? start : fallback, end > 0 ? end : fallback, count);
+        }
+    }
+
+    void collectProducerThreadGap() noexcept
+    {
+        const auto start = producerThreadDropStartUnixNanos.exchange(0, std::memory_order_acq_rel);
+        const auto count = unreportedProducerThreadDrops.exchange(0, std::memory_order_acq_rel);
+        const auto end   = producerThreadDropEndUnixNanos.load(std::memory_order_acquire);
+        if (count > 0)
+        {
+            const auto fallback = unixNanosNow();
+            mergeGap(GapReason::SequenceDiscontinuity,
+                     start > 0 ? start : fallback,
+                     end > 0 ? end : fallback,
+                     count);
+        }
+    }
+
+    auto hasPendingGaps() const noexcept -> bool
+    {
+        return std::any_of(pendingGaps.begin(), pendingGaps.end(), [](const Gap& gap)
+                           {
+                               return gap.active;
+                           });
+    }
+
+    void appendGap(std::string& output, const Gap& gap) const
+    {
+        output.append("{\"gapEnd\":");
+        appendQuoted(output, timestamp(gap.endUnixNanos));
+        output.append(",\"gapId\":");
+        std::string gapId;
+        gapId.reserve(80);
+        gapId.append(bootId.view());
+        gapId.push_back(':');
+        gapId.append(gapReasonName(gap.reason));
+        gapId.push_back(':');
+        appendNumber(gapId, gap.ordinal);
+        appendQuoted(output, gapId);
+        output.append(",\"gapStart\":");
+        appendQuoted(output, timestamp(gap.startUnixNanos));
+        output.append(",\"lostEventCount\":");
+        appendDecimalString(output, gap.lostEventCount);
+        output.append(",\"reason\":");
+        appendQuoted(output, gapReasonName(gap.reason));
+        output.push_back('}');
+    }
+
+    auto serializeBatch(const QueuedRecord* records, const BatchCounts& counts, bool finalWatermark, std::uint64_t currentSpoolBytes, std::uint64_t droppedEventSnapshot, std::int64_t watermarkMillis, std::string_view checksum) -> std::string
+    {
+        std::uint64_t firstEventSequence{};
+        std::uint64_t lastEventSequence{};
+        std::uint64_t firstControlSequence{};
+        std::uint64_t lastControlSequence{};
+        for (std::size_t index = 0; index < counts.total(); ++index)
+        {
+            switch (records[index].type)
+            {
+                case RecordType::Event:
+                {
+                    const auto event = records[index].as<Event>();
+                    if (firstEventSequence == 0)
+                    {
+                        firstEventSequence = event.eventSeq;
+                    }
+                    lastEventSequence = event.eventSeq;
+                    break;
+                }
+                case RecordType::AttributionGap:
+                {
+                    const auto gap = records[index].as<AttributionGap>();
+                    if (firstControlSequence == 0)
+                    {
+                        firstControlSequence = gap.controlSeq;
+                    }
+                    lastControlSequence = gap.controlSeq;
+                    break;
+                }
+                case RecordType::ForgoneMint:
+                {
+                    const auto diagnostic = records[index].as<ForgoneMint>();
+                    if (firstControlSequence == 0)
+                    {
+                        firstControlSequence = diagnostic.controlSeq;
+                    }
+                    lastControlSequence = diagnostic.controlSeq;
+                    break;
+                }
+            }
+        }
+
+        std::string output;
+        output.reserve(1024 + counts.total() * 512);
+        output.append("{\"attributionGaps\":[");
+        auto attributionWritten = false;
+        for (std::size_t index = 0; index < counts.total(); ++index)
+        {
+            if (records[index].type != RecordType::AttributionGap)
+            {
+                continue;
+            }
+            if (attributionWritten)
+            {
+                output.push_back(',');
+            }
+            appendAttributionGap(output, records[index].as<AttributionGap>());
+            attributionWritten = true;
+        }
+        output.append("],\"batchSeq\":");
+        appendDecimalString(output, nextBatchSequence);
+        output.append(",\"bootId\":");
+        appendQuoted(output, bootId.view());
+        if (!checksum.empty())
+        {
+            output.append(",\"checksum\":");
+            appendQuoted(output, checksum);
+        }
+        output.append(",\"controlCount\":");
+        appendNumber(output, counts.controls());
+        output.append(",\"droppedEvents\":");
+        appendDecimalString(output, droppedEventSnapshot);
+        output.append(",\"eventCount\":");
+        appendNumber(output, counts.events);
+        output.append(",\"events\":[");
+        auto eventWritten = false;
+        for (std::size_t index = 0; index < counts.total(); ++index)
+        {
+            if (records[index].type != RecordType::Event)
+            {
+                continue;
+            }
+            if (eventWritten)
+            {
+                output.push_back(',');
+            }
+            appendEvent(output, records[index].as<Event>());
+            eventWritten = true;
+        }
+        output.append("],\"finalWatermark\":");
+        output.append(finalWatermark ? "true" : "false");
+        output.append(",\"firstControlSeq\":");
+        if (firstControlSequence > 0)
+        {
+            appendDecimalString(output, firstControlSequence);
+        }
+        else
+        {
+            output.append("null");
+        }
+        output.append(",\"firstEventSeq\":");
+        if (firstEventSequence > 0)
+        {
+            appendDecimalString(output, firstEventSequence);
+        }
+        else
+        {
+            output.append("null");
+        }
+        output.append(",\"forgoneMints\":[");
+        auto forgoneWritten = false;
+        for (std::size_t index = 0; index < counts.total(); ++index)
+        {
+            if (records[index].type != RecordType::ForgoneMint)
+            {
+                continue;
+            }
+            if (forgoneWritten)
+            {
+                output.push_back(',');
+            }
+            appendForgoneMint(output, records[index].as<ForgoneMint>());
+            forgoneWritten = true;
+        }
+        output.append("],\"gaps\":[");
+        auto gapWritten = false;
+        for (const auto& gap : pendingGaps)
+        {
+            if (!gap.active)
+            {
+                continue;
+            }
+            if (gapWritten)
+            {
+                output.push_back(',');
+            }
+            appendGap(output, gap);
+            gapWritten = true;
+        }
+        output.append("],\"lastControlSeq\":");
+        if (lastControlSequence > 0)
+        {
+            appendDecimalString(output, lastControlSequence);
+        }
+        else
+        {
+            output.append("null");
+        }
+        output.append(",\"lastEventSeq\":");
+        if (lastEventSequence > 0)
+        {
+            appendDecimalString(output, lastEventSequence);
+        }
+        else
+        {
+            output.append("null");
+        }
+        output.append(",\"producerId\":");
+        appendQuoted(output, config.producerId.view());
+        output.append(",\"producerVersion\":");
+        appendQuoted(output, config.producerVersion.view());
+        output.append(",\"reportedSpoolBytes\":");
+        appendDecimalString(output, currentSpoolBytes);
+        output.append(",\"schemaVersion\":2,\"watermarkThrough\":");
+        appendQuoted(output, timestamp(watermarkMillis * 1000000));
+        output.push_back('}');
+        return output;
+    }
+
+    auto persist(QueuedRecord* records, const BatchCounts& counts, bool finalWatermark, bool bypassRetryBackoff = false) noexcept -> PersistResult
+    {
+        if (!bypassRetryBackoff && SteadyClock::now() < retryPersistenceAfter)
+        {
+            return lastPersistFailure;
+        }
+        const auto gameTickSequenceSnapshot = gameTickSequence.load(std::memory_order_acquire);
+        const auto gameTickNanosSnapshot    = latestGameTickUnixNanos.load(std::memory_order_relaxed);
+        const auto noteControlFailure       = [this, &counts](GapReason reason)
+        {
+            if (counts.total() == 0)
+            {
+                const auto now = unixNanosNow();
+                mergeGap(reason, now, now, 0);
+            }
+        };
+        try
+        {
+            const auto      directory = std::filesystem::path(config.spoolDirectory.view());
+            std::error_code error;
+            std::filesystem::create_directories(directory, error);
+            if (error)
+            {
+                lastError.store(ErrorCode::SpoolDirectoryFailure, std::memory_order_relaxed);
+                noteControlFailure(GapReason::SpoolWriteFailure);
+                lastPersistFailure    = PersistResult::Failed;
+                retryPersistenceAfter = SteadyClock::now() + std::chrono::seconds(1);
+                return PersistResult::Failed;
+            }
+
+            const auto currentBytes = spoolBytes(directory);
+            reportedSpoolBytes.store(currentBytes, std::memory_order_relaxed);
+
+            for (std::size_t index = 0; index < counts.total(); ++index)
+            {
+                std::int64_t occurredAt{};
+                switch (records[index].type)
+                {
+                    case RecordType::Event:
+                        occurredAt = records[index].as<Event>().occurredAtUnixNanos;
+                        break;
+                    case RecordType::AttributionGap:
+                        occurredAt = records[index].as<AttributionGap>().occurredAtUnixNanos;
+                        break;
+                    case RecordType::ForgoneMint:
+                        occurredAt = records[index].as<ForgoneMint>().occurredAtUnixNanos;
+                        break;
+                }
+                const auto normalizedNanos = std::max(lastWatermarkUnixMillis + 1, occurredAt / 1000000) * 1000000;
+                switch (records[index].type)
+                {
+                    case RecordType::Event:
+                    {
+                        auto event                = records[index].as<Event>();
+                        event.occurredAtUnixNanos = normalizedNanos;
+                        records[index]            = QueuedRecord::from(RecordType::Event, event);
+                        break;
+                    }
+                    case RecordType::AttributionGap:
+                    {
+                        auto gap                = records[index].as<AttributionGap>();
+                        gap.occurredAtUnixNanos = normalizedNanos;
+                        records[index]          = QueuedRecord::from(RecordType::AttributionGap, gap);
+                        break;
+                    }
+                    case RecordType::ForgoneMint:
+                    {
+                        auto diagnostic                = records[index].as<ForgoneMint>();
+                        diagnostic.occurredAtUnixNanos = normalizedNanos;
+                        records[index]                 = QueuedRecord::from(RecordType::ForgoneMint, diagnostic);
+                        break;
+                    }
+                }
+            }
+
+            auto latestCoveredNanos =
+                std::max(lastWatermarkUnixMillis * 1000000, gameTickNanosSnapshot);
+            for (std::size_t index = 0; index < counts.total(); ++index)
+            {
+                switch (records[index].type)
+                {
+                    case RecordType::Event:
+                        latestCoveredNanos = std::max(latestCoveredNanos, records[index].as<Event>().occurredAtUnixNanos);
+                        break;
+                    case RecordType::AttributionGap:
+                        latestCoveredNanos =
+                            std::max(latestCoveredNanos, records[index].as<AttributionGap>().occurredAtUnixNanos);
+                        break;
+                    case RecordType::ForgoneMint:
+                        latestCoveredNanos =
+                            std::max(latestCoveredNanos, records[index].as<ForgoneMint>().occurredAtUnixNanos);
+                        break;
+                }
+            }
+            for (const auto& gap : pendingGaps)
+            {
+                if (gap.active)
+                {
+                    latestCoveredNanos = std::max(latestCoveredNanos, gap.endUnixNanos);
+                }
+            }
+            const auto watermarkMillis = std::max(lastWatermarkUnixMillis, latestCoveredNanos / 1000000);
+            const auto droppedSnapshot = droppedEvents.load(std::memory_order_relaxed);
+            const auto canonicalWithoutChecksum =
+                serializeBatch(records, counts, finalWatermark, currentBytes, droppedSnapshot, watermarkMillis, {});
+            if (canonicalWithoutChecksum.size() > MaxUncompressedBatchBytes)
+            {
+                lastError.store(ErrorCode::SerializeFailure, std::memory_order_relaxed);
+                noteControlFailure(GapReason::SpoolWriteFailure);
+                lastPersistFailure    = PersistResult::Failed;
+                retryPersistenceAfter = SteadyClock::now() + std::chrono::seconds(1);
+                return PersistResult::Failed;
+            }
+            const auto checksum = sha256(canonicalWithoutChecksum);
+            const auto completedJson =
+                serializeBatch(records, counts, finalWatermark, currentBytes, droppedSnapshot, watermarkMillis, checksum);
+            if (completedJson.size() > MaxUncompressedBatchBytes)
+            {
+                lastError.store(ErrorCode::SerializeFailure, std::memory_order_relaxed);
+                noteControlFailure(GapReason::SpoolWriteFailure);
+                lastPersistFailure    = PersistResult::Failed;
+                retryPersistenceAfter = SteadyClock::now() + std::chrono::seconds(1);
+                return PersistResult::Failed;
+            }
+
+            std::vector<unsigned char> compressed;
+            if (!compressGzip(completedJson, compressed))
+            {
+                lastError.store(ErrorCode::CompressFailure, std::memory_order_relaxed);
+                noteControlFailure(GapReason::SpoolWriteFailure);
+                lastPersistFailure    = PersistResult::Failed;
+                retryPersistenceAfter = SteadyClock::now() + std::chrono::seconds(1);
+                return PersistResult::Failed;
+            }
+
+            const auto usesControlReserve = counts.events == 0 && (counts.controls() > 0 || hasPendingGaps() || finalWatermark);
+            const auto limit              = usesControlReserve ? config.spoolHardCapBytes : config.spoolHardCapBytes - config.spoolControlReserveBytes;
+            if (currentBytes > limit || compressed.size() > limit - currentBytes)
+            {
+                lastError.store(ErrorCode::SpoolCapacity, std::memory_order_relaxed);
+                noteControlFailure(GapReason::SpoolCapacity);
+                lastPersistFailure    = PersistResult::Capacity;
+                retryPersistenceAfter = SteadyClock::now() + std::chrono::seconds(1);
+                return PersistResult::Capacity;
+            }
+
+            std::array<char, 96> filename{};
+            const auto           nameLength = std::snprintf(filename.data(), filename.size(), "economy-%013lld-%.*s-%020llu.json.gz", static_cast<long long>(bootStartedUnixMillis), static_cast<int>(bootId.length), bootId.bytes.data(), static_cast<unsigned long long>(nextBatchSequence));
+            if (nameLength <= 0 || static_cast<std::size_t>(nameLength) >= filename.size())
+            {
+                lastError.store(ErrorCode::SerializeFailure, std::memory_order_relaxed);
+                noteControlFailure(GapReason::SpoolWriteFailure);
+                lastPersistFailure    = PersistResult::Failed;
+                retryPersistenceAfter = SteadyClock::now() + std::chrono::seconds(1);
+                return PersistResult::Failed;
+            }
+            const auto completed   = directory / std::string(filename.data(), static_cast<std::size_t>(nameLength));
+            const auto temporary   = directory / (std::string(".") + filename.data() + ".tmp");
+            const auto writeResult = writeDurableFile(temporary, completed, compressed);
+            if (writeResult == DurableWriteResult::Failed)
+            {
+                lastError.store(ErrorCode::SpoolWriteFailure, std::memory_order_relaxed);
+                noteControlFailure(GapReason::SpoolWriteFailure);
+                lastPersistFailure    = PersistResult::Failed;
+                retryPersistenceAfter = SteadyClock::now() + std::chrono::seconds(1);
+                return PersistResult::Failed;
+            }
+
+            lastWatermarkUnixMillis = watermarkMillis;
+            lastDurableGameTickSequence =
+                std::max(lastDurableGameTickSequence, gameTickSequenceSnapshot);
+            ++nextBatchSequence;
+            batchesWritten.fetch_add(1, std::memory_order_relaxed);
+            reportedSpoolBytes.store(currentBytes + compressed.size(), std::memory_order_relaxed);
+            lastDurableWrite = SteadyClock::now();
+            for (auto& gap : pendingGaps)
+            {
+                gap = {};
+            }
+            retryPersistenceAfter = {};
+            if (writeResult == DurableWriteResult::VisibleDirectorySyncUncertain)
+            {
+                const auto now = unixNanosNow();
+                mergeGap(GapReason::SpoolWriteFailure, now, now, 0);
+                lastError.store(ErrorCode::SpoolWriteFailure, std::memory_order_relaxed);
+            }
+            else
+            {
+                lastError.store(ErrorCode::None, std::memory_order_relaxed);
+            }
+            return PersistResult::Written;
+        }
+        catch (...)
+        {
+            lastError.store(ErrorCode::SpoolWriteFailure, std::memory_order_relaxed);
+            noteControlFailure(GapReason::SpoolWriteFailure);
+            lastPersistFailure    = PersistResult::Failed;
+            retryPersistenceAfter = SteadyClock::now() + std::chrono::seconds(1);
+            return PersistResult::Failed;
+        }
+    }
+
+    [[nodiscard]] auto recordTime(const QueuedRecord& record) const noexcept -> std::int64_t
+    {
+        switch (record.type)
+        {
+            case RecordType::Event:
+                return record.as<Event>().occurredAtUnixNanos;
+            case RecordType::AttributionGap:
+                return record.as<AttributionGap>().occurredAtUnixNanos;
+            case RecordType::ForgoneMint:
+                return record.as<ForgoneMint>().occurredAtUnixNanos;
+        }
+        return 0;
+    }
+
+    auto prepareRecord(QueuedRecord& record, BatchCounts& counts) noexcept -> bool
+    {
+        switch (record.type)
+        {
+            case RecordType::Event:
+            {
+                auto event = record.as<Event>();
+                if (!isValidEvent(event))
+                {
+                    return false;
+                }
+                event.eventSeq = nextEventSequence++;
+                record         = QueuedRecord::from(RecordType::Event, event);
+                ++counts.events;
+                return true;
+            }
+            case RecordType::AttributionGap:
+            {
+                auto gap = record.as<AttributionGap>();
+                if (!isValidAttributionGap(gap))
+                {
+                    return false;
+                }
+                gap.controlSeq = nextControlSequence++;
+                record         = QueuedRecord::from(RecordType::AttributionGap, gap);
+                ++counts.attributionGaps;
+                return true;
+            }
+            case RecordType::ForgoneMint:
+            {
+                auto diagnostic = record.as<ForgoneMint>();
+                if (!isValidForgoneMint(diagnostic))
+                {
+                    return false;
+                }
+                diagnostic.controlSeq = nextControlSequence++;
+                record                = QueuedRecord::from(RecordType::ForgoneMint, diagnostic);
+                ++counts.forgoneMints;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    void dropRecords(QueuedRecord* records, const BatchCounts& counts, GapReason reason) noexcept
+    {
+        if (counts.total() == 0)
+        {
+            return;
+        }
+        auto start = recordTime(records[0]);
+        auto end   = start;
+        for (std::size_t index = 1; index < counts.total(); ++index)
+        {
+            start = std::min(start, recordTime(records[index]));
+            end   = std::max(end, recordTime(records[index]));
+        }
+        mergeGap(reason, start, end, counts.total());
+        droppedEvents.fetch_add(counts.total(), std::memory_order_relaxed);
+        if (reason == GapReason::SpoolCapacity)
+        {
+            spoolCapacityEvents.fetch_add(counts.total(), std::memory_order_relaxed);
+        }
+        else if (reason == GapReason::SpoolWriteFailure)
+        {
+            spoolWriteFailureEvents.fetch_add(counts.total(), std::memory_order_relaxed);
+        }
+    }
+
+    void flushRecords(std::array<QueuedRecord, MaxEventsPerBatch>& buffer, BatchCounts& counts, bool bypassRetryBackoff = false) noexcept
+    {
+        if (counts.total() == 0)
+        {
+            return;
+        }
+        const auto result = persist(buffer.data(), counts, false, bypassRetryBackoff);
+        if (result == PersistResult::Capacity)
+        {
+            dropRecords(buffer.data(), counts, GapReason::SpoolCapacity);
+        }
+        else if (result == PersistResult::Failed)
+        {
+            dropRecords(buffer.data(), counts, GapReason::SpoolWriteFailure);
+        }
+        counts = {};
+    }
+
+    void run() noexcept
+    {
+        lastDurableWrite = SteadyClock::now();
+        std::array<QueuedRecord, MaxEventsPerBatch> buffer;
+        BatchCounts                                 counts;
+        auto                                        firstBufferedAt = SteadyClock::time_point{};
+
+        while (!stopRequested.load(std::memory_order_acquire))
+        {
+            collectQueueGap();
+            collectProducerThreadGap();
+            while (counts.total() < buffer.size() && counts.attributionGaps < 100 && counts.forgoneMints < 100)
+            {
+                QueuedRecord record;
+                if (!queue->try_dequeue(record))
+                {
+                    break;
+                }
+                const auto eventTime = recordTime(record);
+                if (!prepareRecord(record, counts))
+                {
+                    const auto fallbackTime = eventTime > 0 ? eventTime : unixNanosNow();
+                    mergeGap(GapReason::SequenceDiscontinuity, fallbackTime, fallbackTime, 1);
+                    droppedEvents.fetch_add(1, std::memory_order_relaxed);
+                    invalidEvents.fetch_add(1, std::memory_order_relaxed);
+                    continue;
+                }
+                buffer[counts.total() - 1] = record;
+                if (counts.total() == 1)
+                {
+                    firstBufferedAt = SteadyClock::now();
+                }
+            }
+
+            const auto now                = SteadyClock::now();
+            const auto recordLimitReached = counts.total() == buffer.size() || counts.attributionGaps == 100 ||
+                                            counts.forgoneMints == 100;
+            if (recordLimitReached ||
+                (counts.total() > 0 && now - firstBufferedAt >= std::chrono::milliseconds(config.flushIntervalMilliseconds)))
+            {
+                flushRecords(buffer, counts);
+                if (hasPendingGaps())
+                {
+                    persist(nullptr, {}, false);
+                }
+                continue;
+            }
+            if (counts.total() == 0 && hasPendingGaps())
+            {
+                persist(nullptr, {}, false);
+            }
+            else if (counts.total() == 0 &&
+                     now - lastDurableWrite >= std::chrono::milliseconds(config.heartbeatIntervalMilliseconds) &&
+                     gameTickSequence.load(std::memory_order_acquire) > lastDurableGameTickSequence)
+            {
+                persist(nullptr, {}, false);
+            }
+
+            std::unique_lock lock(wakeMutex);
+            wakeCondition.wait_for(lock, WorkerPollInterval, [this]
+                                   {
+                                       return stopRequested.load(std::memory_order_acquire);
+                                   });
+        }
+
+        for (;;)
+        {
+            while (counts.total() < buffer.size() && counts.attributionGaps < 100 && counts.forgoneMints < 100)
+            {
+                QueuedRecord record;
+                if (!queue->try_dequeue(record))
+                {
+                    break;
+                }
+                const auto eventTime = recordTime(record);
+                if (!prepareRecord(record, counts))
+                {
+                    const auto fallbackTime = eventTime > 0 ? eventTime : unixNanosNow();
+                    mergeGap(GapReason::SequenceDiscontinuity, fallbackTime, fallbackTime, 1);
+                    droppedEvents.fetch_add(1, std::memory_order_relaxed);
+                    invalidEvents.fetch_add(1, std::memory_order_relaxed);
+                    continue;
+                }
+                buffer[counts.total() - 1] = record;
+            }
+            if (counts.total() == 0)
+            {
+                break;
+            }
+            flushRecords(buffer, counts, true);
+        }
+        collectQueueGap();
+        collectProducerThreadGap();
+        persist(nullptr, {}, true, true);
+    }
+};
+
+Producer::Producer()
+: impl_(std::make_unique<Impl>())
+{
+}
+
+Producer::~Producer()
+{
+    stop();
+}
+
+auto Producer::start(const ProducerConfig& config) noexcept -> StartResult
+{
+    if (!config.enabled)
+    {
+        return StartResult::Disabled;
+    }
+    if (impl_->state.load(std::memory_order_acquire) != RunState::Disabled || impl_->worker.joinable())
+    {
+        return StartResult::AlreadyStarted;
+    }
+    if (!isSafeToken(config.producerId.view()) || !isSafeToken(config.contentVersion.view()) ||
+        !isSafeToken(config.producerVersion.view()) || config.spoolDirectory.empty() || config.queueCapacity < 2 ||
+        config.queueCapacity > MaxQueueCapacity || config.spoolHardCapBytes < MinHardCapBytes ||
+        config.spoolControlReserveBytes < MinControlReserveBytes ||
+        config.spoolControlReserveBytes >= config.spoolHardCapBytes || config.flushIntervalMilliseconds < 10 ||
+        config.flushIntervalMilliseconds > 5000 || config.heartbeatIntervalMilliseconds < config.flushIntervalMilliseconds ||
+        config.heartbeatIntervalMilliseconds > 30000)
+    {
+        impl_->lastError.store(ErrorCode::InvalidConfiguration, std::memory_order_relaxed);
+        return StartResult::InvalidConfiguration;
+    }
+
+    try
+    {
+        impl_->config                = config;
+        impl_->bootId                = generateBootId();
+        impl_->bootStartedUnixMillis = unixNanosNow() / 1000000;
+        impl_->producerToken.reset();
+        impl_->queue            = std::make_unique<Producer::Impl::RecordQueue>(config.queueCapacity, 1, 0);
+        impl_->producerToken    = std::make_unique<moodycamel::ProducerToken>(*impl_->queue);
+        impl_->producerThreadId = std::this_thread::get_id();
+        impl_->latestGameTickUnixNanos.store(unixNanosNow(), std::memory_order_relaxed);
+        impl_->gameTickSequence.store(1, std::memory_order_relaxed);
+        impl_->lastDurableGameTickSequence = 0;
+        impl_->stopRequested               = false;
+        impl_->state.store(RunState::Running, std::memory_order_release);
+        impl_->worker = std::thread([implementation = impl_.get()]
+                                    {
+                                        implementation->run();
+                                    });
+        return StartResult::Started;
+    }
+    catch (...)
+    {
+        impl_->state.store(RunState::Disabled, std::memory_order_release);
+        impl_->producerToken.reset();
+        impl_->queue.reset();
+        impl_->producerThreadId = {};
+        impl_->lastError.store(ErrorCode::WorkerStartFailed, std::memory_order_relaxed);
+        return StartResult::WorkerStartFailed;
+    }
+}
+
+auto Producer::startFromEnvironment() noexcept -> StartResult
+{
+    return start(producerConfigFromEnvironment());
+}
+
+void Producer::stop() noexcept
+{
+    auto expected = RunState::Running;
+    if (!impl_->state.compare_exchange_strong(expected, RunState::Stopping, std::memory_order_acq_rel))
+    {
+        if (expected == RunState::Stopping && impl_->worker.joinable())
+        {
+            impl_->worker.join();
+            impl_->producerToken.reset();
+            impl_->queue.reset();
+            impl_->producerThreadId = {};
+            impl_->state.store(RunState::Disabled, std::memory_order_release);
+        }
+        return;
+    }
+
+    impl_->stopRequested.store(true, std::memory_order_release);
+    impl_->wakeCondition.notify_all();
+    if (impl_->worker.joinable())
+    {
+        impl_->worker.join();
+    }
+    impl_->producerToken.reset();
+    impl_->queue.reset();
+    impl_->producerThreadId = {};
+    impl_->state.store(RunState::Disabled, std::memory_order_release);
+}
+
+void Producer::noteGameTick() noexcept
+{
+    if (impl_->state.load(std::memory_order_acquire) != RunState::Running ||
+        std::this_thread::get_id() != impl_->producerThreadId)
+    {
+        return;
+    }
+
+    impl_->latestGameTickUnixNanos.store(unixNanosNow(), std::memory_order_relaxed);
+    impl_->gameTickSequence.fetch_add(1, std::memory_order_release);
+}
+
+auto Producer::tryRecord(Event event) noexcept -> RecordResult
+{
+    if (!enabled())
+    {
+        return RecordResult::Disabled;
+    }
+    if (event.contentVersion.empty())
+    {
+        event.contentVersion = impl_->config.contentVersion;
+    }
+    if (event.evidenceVersion.empty())
+    {
+        event.evidenceVersion = impl_->config.producerVersion;
+    }
+    return impl_->enqueue(QueuedRecord::from(RecordType::Event, event), event.occurredAtUnixNanos);
+}
+
+auto Producer::tryRecord(AttributionGap gap) noexcept -> RecordResult
+{
+    if (!enabled())
+    {
+        return RecordResult::Disabled;
+    }
+    if (gap.contentVersion.empty())
+    {
+        gap.contentVersion = impl_->config.contentVersion;
+    }
+    if (gap.evidenceVersion.empty())
+    {
+        gap.evidenceVersion = impl_->config.producerVersion;
+    }
+    return impl_->enqueue(QueuedRecord::from(RecordType::AttributionGap, gap), gap.occurredAtUnixNanos);
+}
+
+auto Producer::tryRecord(ForgoneMint diagnostic) noexcept -> RecordResult
+{
+    if (!enabled())
+    {
+        return RecordResult::Disabled;
+    }
+    if (diagnostic.contentVersion.empty())
+    {
+        diagnostic.contentVersion = impl_->config.contentVersion;
+    }
+    if (diagnostic.evidenceVersion.empty())
+    {
+        diagnostic.evidenceVersion = impl_->config.producerVersion;
+    }
+    return impl_->enqueue(QueuedRecord::from(RecordType::ForgoneMint, diagnostic), diagnostic.occurredAtUnixNanos);
+}
+
+auto Producer::nextTransactionId(std::string_view prefix) noexcept -> TransactionId
+{
+    TransactionId transaction;
+    if (impl_->state.load(std::memory_order_acquire) != RunState::Running || !isSafeToken(prefix))
+    {
+        return transaction;
+    }
+
+    const auto            ordinal = impl_->transactionOrdinal.fetch_add(1, std::memory_order_relaxed) + 1;
+    std::array<char, 128> value{};
+    const auto            result = std::snprintf(value.data(), value.size(), "%.*s:%.*s:%llu", static_cast<int>(impl_->bootId.length), impl_->bootId.bytes.data(), static_cast<int>(prefix.size()), prefix.data(), static_cast<unsigned long long>(ordinal));
+    if (result <= 0 || static_cast<std::size_t>(result) >= value.size())
+    {
+        return transaction;
+    }
+    static_cast<void>(transaction.assign({ value.data(), static_cast<std::size_t>(result) }));
+    return transaction;
+}
+
+auto Producer::enabled() const noexcept -> bool
+{
+    return impl_->state.load(std::memory_order_acquire) == RunState::Running;
+}
+
+auto Producer::metrics() const noexcept -> MetricsSnapshot
+{
+    return {
+        .enqueuedEvents      = impl_->enqueuedEvents.load(std::memory_order_relaxed),
+        .droppedEvents       = impl_->droppedEvents.load(std::memory_order_relaxed),
+        .queueOverflowEvents = impl_->queueOverflowEvents.load(std::memory_order_relaxed),
+        .producerThreadViolationEvents =
+            impl_->producerThreadViolationEvents.load(std::memory_order_relaxed),
+        .invalidEvents           = impl_->invalidEvents.load(std::memory_order_relaxed),
+        .spoolCapacityEvents     = impl_->spoolCapacityEvents.load(std::memory_order_relaxed),
+        .spoolWriteFailureEvents = impl_->spoolWriteFailureEvents.load(std::memory_order_relaxed),
+        .batchesWritten          = impl_->batchesWritten.load(std::memory_order_relaxed),
+        .reportedSpoolBytes      = impl_->reportedSpoolBytes.load(std::memory_order_relaxed),
+    };
+}
+
+auto Producer::lastError() const noexcept -> const char*
+{
+    switch (impl_->lastError.load(std::memory_order_relaxed))
+    {
+        case ErrorCode::None:
+            return "none";
+        case ErrorCode::InvalidConfiguration:
+            return "invalid configuration";
+        case ErrorCode::WorkerStartFailed:
+            return "worker start failed";
+        case ErrorCode::SpoolDirectoryFailure:
+            return "spool directory unavailable";
+        case ErrorCode::SerializeFailure:
+            return "batch serialization failed";
+        case ErrorCode::CompressFailure:
+            return "batch compression failed";
+        case ErrorCode::SpoolCapacity:
+            return "spool capacity reached";
+        case ErrorCode::SpoolWriteFailure:
+            return "durable spool write failed";
+    }
+    return "unknown";
+}
+
+auto globalProducer() noexcept -> Producer&
+{
+    static Producer producer;
+    return producer;
+}
+
+auto producerConfigFromEnvironment() noexcept -> ProducerConfig
+{
+    ProducerConfig config;
+    config.enabled = truthy(std::getenv("PHOENIX_ECONOMY_TELEMETRY_ENABLED"));
+    assignEnvironment(config.producerId, "PHOENIX_ECONOMY_PRODUCER_ID");
+    assignEnvironment(config.contentVersion, "PHOENIX_ECONOMY_CONTENT_VERSION");
+    assignEnvironment(config.producerVersion, "PHOENIX_ECONOMY_PRODUCER_VERSION", "phoenix-economy-module-0.1.0");
+    assignEnvironment(config.spoolDirectory, "PHOENIX_ECONOMY_SPOOL_DIRECTORY");
+    config.queueCapacity = parseUnsignedEnvironment<std::size_t>("PHOENIX_ECONOMY_QUEUE_CAPACITY", config.queueCapacity);
+    config.spoolHardCapBytes =
+        parseUnsignedEnvironment<std::uint64_t>("PHOENIX_ECONOMY_SPOOL_HARD_CAP_BYTES", config.spoolHardCapBytes);
+    config.spoolControlReserveBytes = parseUnsignedEnvironment<std::uint64_t>(
+        "PHOENIX_ECONOMY_SPOOL_CONTROL_RESERVE_BYTES", config.spoolControlReserveBytes);
+    config.flushIntervalMilliseconds = parseUnsignedEnvironment<std::uint32_t>(
+        "PHOENIX_ECONOMY_FLUSH_INTERVAL_MS", config.flushIntervalMilliseconds);
+    config.heartbeatIntervalMilliseconds = parseUnsignedEnvironment<std::uint32_t>(
+        "PHOENIX_ECONOMY_HEARTBEAT_INTERVAL_MS", config.heartbeatIntervalMilliseconds);
+    return config;
+}
+
+#ifdef PHOENIX_ECONOMY_TESTING
+auto recordQueueAllocationCallsForCurrentThread() noexcept -> std::uint64_t
+{
+    return recordQueueAllocationCalls;
+}
+#endif
+
+} // namespace phoenix::economy

--- a/modules/phoenix/economy/cpp/economy_producer.h
+++ b/modules/phoenix/economy/cpp/economy_producer.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include "economy_event.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string_view>
+
+namespace phoenix::economy
+{
+
+constexpr std::size_t MaxEventsPerBatch = 500;
+
+struct ProducerConfig
+{
+    bool enabled{};
+
+    FixedString<128> producerId;
+    ContentVersion   contentVersion;
+    FixedString<64>  producerVersion;
+    FixedString<512> spoolDirectory;
+
+    std::size_t   queueCapacity{ 8192 };
+    std::uint64_t spoolHardCapBytes{ 256ULL * 1024ULL * 1024ULL };
+    std::uint64_t spoolControlReserveBytes{ 1024ULL * 1024ULL };
+    std::uint32_t flushIntervalMilliseconds{ 5000 };
+    std::uint32_t heartbeatIntervalMilliseconds{ 30000 };
+};
+
+enum class StartResult : std::uint8_t
+{
+    Started,
+    Disabled,
+    AlreadyStarted,
+    InvalidConfiguration,
+    WorkerStartFailed,
+};
+
+enum class RecordResult : std::uint8_t
+{
+    Enqueued,
+    Disabled,
+    InvalidEvent,
+    QueueFull,
+};
+
+struct MetricsSnapshot
+{
+    std::uint64_t enqueuedEvents{};
+    std::uint64_t droppedEvents{};
+    std::uint64_t queueOverflowEvents{};
+    std::uint64_t producerThreadViolationEvents{};
+    std::uint64_t invalidEvents{};
+    std::uint64_t spoolCapacityEvents{};
+    std::uint64_t spoolWriteFailureEvents{};
+    std::uint64_t batchesWritten{};
+    std::uint64_t reportedSpoolBytes{};
+};
+
+class Producer final
+{
+public:
+    Producer();
+    ~Producer();
+
+    Producer(const Producer&)            = delete;
+    Producer& operator=(const Producer&) = delete;
+    Producer(Producer&&)                 = delete;
+    Producer& operator=(Producer&&)      = delete;
+
+    [[nodiscard]] auto start(const ProducerConfig& config) noexcept -> StartResult;
+    [[nodiscard]] auto startFromEnvironment() noexcept -> StartResult;
+
+    // stop() joins the spool worker and asks it to durably write a final
+    // watermark. It is idempotent and must be called during graceful shutdown.
+    void stop() noexcept;
+
+    // start(), noteGameTick(), nextTransactionId(), and every tryRecord()
+    // call belong to the same map/game thread. start() pre-registers the
+    // queue's sole explicit producer token before returning; off-thread
+    // tryRecord() calls are rejected and reported as sequence gaps.
+    void noteGameTick() noexcept;
+
+    [[nodiscard]] auto tryRecord(Event event) noexcept -> RecordResult;
+    [[nodiscard]] auto tryRecord(AttributionGap gap) noexcept -> RecordResult;
+    [[nodiscard]] auto tryRecord(ForgoneMint diagnostic) noexcept -> RecordResult;
+    [[nodiscard]] auto nextTransactionId(std::string_view prefix) noexcept -> TransactionId;
+    [[nodiscard]] auto enabled() const noexcept -> bool;
+    [[nodiscard]] auto metrics() const noexcept -> MetricsSnapshot;
+    [[nodiscard]] auto lastError() const noexcept -> const char*;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+[[nodiscard]] auto globalProducer() noexcept -> Producer&;
+[[nodiscard]] auto producerConfigFromEnvironment() noexcept -> ProducerConfig;
+
+#ifdef PHOENIX_ECONOMY_TESTING
+[[nodiscard]] auto recordQueueAllocationCallsForCurrentThread() noexcept -> std::uint64_t;
+#endif
+
+} // namespace phoenix::economy

--- a/modules/phoenix/economy/lua/economy_telemetry.lua
+++ b/modules/phoenix/economy/lua/economy_telemetry.lua
@@ -1,0 +1,495 @@
+-----------------------------------
+-- Phoenix economy telemetry semantic attribution
+--
+-- The C++ producer is disabled unless PHOENIX_ECONOMY_TELEMETRY_ENABLED
+-- is explicitly enabled. These wrappers only maintain synchronous,
+-- in-memory attribution context; they never perform I/O.
+-----------------------------------
+local enabledValue = string.lower(os.getenv('PHOENIX_ECONOMY_TELEMETRY_ENABLED') or '')
+local enabled =
+    enabledValue == '1' or
+    enabledValue == 'true' or
+    enabledValue == 'yes' or
+    enabledValue == 'on'
+
+if not enabled then
+    -- A plain table keeps the module loader contract while registering no
+    -- overrides, so the default-off path has no gameplay overhead.
+    return { disabled = true }
+end
+
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('phoenix_economy_telemetry')
+
+local function pack(...)
+    return { n = select('#', ...), ... }
+end
+
+local function telemetryEnabled()
+    return
+        xi ~= nil and
+        xi.economy ~= nil and
+        xi.economy.enabled ~= nil and
+        xi.economy.enabled()
+end
+
+local function withContext(player, context, fn, ...)
+    if
+        not telemetryEnabled() or
+        player == nil or
+        xi.economy.beginContext == nil or
+        not xi.economy.beginContext(player, context)
+    then
+        return fn(...)
+    end
+
+    local result = pack(pcall(fn, ...))
+    xi.economy.endContext(player)
+
+    if not result[1] then
+        error(result[2], 0)
+    end
+
+    return unpack(result, 2, result.n)
+end
+
+local function withContexts(players, context, fn, ...)
+    if not telemetryEnabled() or type(players) ~= 'table' then
+        return fn(...)
+    end
+
+    local pushed = {}
+    for _, player in ipairs(players) do
+        if
+            player ~= nil and
+            xi.economy.beginContext ~= nil and
+            xi.economy.beginContext(player, context)
+        then
+            table.insert(pushed, player)
+        end
+    end
+
+    local result = pack(pcall(fn, ...))
+    for index = #pushed, 1, -1 do
+        xi.economy.endContext(pushed[index])
+    end
+
+    if not result[1] then
+        error(result[2], 0)
+    end
+
+    return unpack(result, 2, result.n)
+end
+
+local function invokeWalletMutation(player, operation, requested, fn, ...)
+    if
+        not telemetryEnabled() or
+        player == nil or
+        xi.economy.beginLuaWallet == nil or
+        not xi.economy.beginLuaWallet(player)
+    then
+        return fn(...)
+    end
+
+    local before = player:getGil()
+    local result = pack(pcall(fn, ...))
+    local after = player:getGil()
+    xi.economy.endLuaWallet(player, before, after, requested or 0, operation)
+
+    if not result[1] then
+        error(result[2], 0)
+    end
+
+    return unpack(result, 2, result.n)
+end
+
+local function isEntityType(value, method)
+    if type(value) ~= 'userdata' then
+        return false
+    end
+
+    local result = pack(pcall(function()
+        return value[method](value)
+    end))
+
+    return result[1] and result[2] == true
+end
+
+local function findPlayer(...)
+    for index = 1, select('#', ...) do
+        local value = select(index, ...)
+        if isEntityType(value, 'isPC') then
+            return value
+        end
+    end
+end
+
+local function findNpc(...)
+    for index = 1, select('#', ...) do
+        local value = select(index, ...)
+        if isEntityType(value, 'isNPC') then
+            return value
+        end
+    end
+end
+
+local function entitySource(context, entity)
+    if entity == nil then
+        return context
+    end
+
+    if entity:isNPC() then
+        context.sourceType = 'npc'
+        context.scriptKey = nil
+        context.systemKey = nil
+        context.npcId = entity:getID()
+        context.zoneId = entity:getZoneID()
+    elseif entity:isMob() then
+        context.sourceType = 'mob'
+        context.scriptKey = nil
+        context.systemKey = nil
+        context.serviceKey = nil
+        context.mobSpawnId = entity:getID()
+        context.mobPoolId = entity:getPool()
+        context.zoneId = entity:getZoneID()
+    end
+
+    return context
+end
+
+local function makeStaticOverride(mintCategory, burnCategory, serviceKey)
+    return function(...)
+        local player = findPlayer(...)
+        local context = entitySource({
+            mintCategory = mintCategory,
+            burnCategory = burnCategory,
+            sourceType = 'system',
+            systemKey = serviceKey,
+        }, findNpc(...))
+
+        if context.sourceType == 'npc' then
+            context.serviceKey = serviceKey
+        end
+
+        return withContext(player, context, super, ...)
+    end
+end
+
+-- Observe actual applied deltas while preserving the stock Lua bindings and
+-- their return values. The C++ observer suppresses the synchronous ITEM_NUM
+-- packet during super so each mutation produces one semantic record or gap.
+m:addOverride('CBaseEntity.addGil', function(player, amount)
+    return invokeWalletMutation(player, 'add', amount, super, player, amount)
+end)
+
+m:addOverride('CBaseEntity.delGil', function(player, amount)
+    return invokeWalletMutation(player, 'del', amount, super, player, amount)
+end)
+
+m:addOverride('CBaseEntity.setGil', function(player, amount)
+    return invokeWalletMutation(player, 'set', amount, super, player, amount)
+end)
+
+m:addOverride('CBaseEntity.confirmTrade', function(player)
+    return invokeWalletMutation(player, 'confirm_trade', 0, super, player)
+end)
+
+m:addOverride('CBaseEntity.tradeComplete', function(player)
+    return invokeWalletMutation(player, 'trade_complete', 0, super, player)
+end)
+
+-- Normal shop packets contain only a menu slot. Capture the stable active NPC
+-- at menu creation and let the native correlator bind it to later purchases.
+m:addOverride('CBaseEntity.createShop', function(player, ...)
+    local result = pack(pcall(super, player, ...))
+    if result[1] and telemetryEnabled() and xi.economy.captureShop ~= nil then
+        xi.economy.captureShop(player)
+    end
+
+    if not result[1] then
+        error(result[2], 0)
+    end
+
+    return unpack(result, 2, result.n)
+end)
+
+local function contextForContainer(container)
+    if type(container.questId) == 'number' and type(container.areaId) == 'number' then
+        return {
+            mintCategory = 'quest_reward',
+            burnCategory = 'quest_fee',
+            sourceType = 'quest',
+            questLogId = container.areaId,
+            questId = container.questId,
+        }
+    elseif type(container.missionId) == 'number' and type(container.areaId) == 'number' then
+        return {
+            mintCategory = 'mission_reward',
+            burnCategory = 'quest_fee',
+            sourceType = 'mission',
+            missionLogId = container.areaId,
+            missionId = container.missionId,
+        }
+    elseif type(container.battlefieldId) == 'number' then
+        return {
+            mintCategory = 'battlefield_reward',
+            sourceType = 'battlefield',
+            battlefieldId = container.battlefieldId,
+        }
+    end
+end
+
+local wrappedContainers = setmetatable({}, { __mode = 'k' })
+
+local function wrapContainerTable(value, context, seen)
+    if seen[value] then
+        return
+    end
+
+    seen[value] = true
+    for key, entry in pairs(value) do
+        if type(entry) == 'function' then
+            local original = entry
+            value[key] = function(...)
+                return withContext(findPlayer(...), context, original, ...)
+            end
+        elseif type(entry) == 'table' then
+            wrapContainerTable(entry, context, seen)
+        end
+    end
+end
+
+-- Wrap interaction containers before InteractionLookup preprocesses their
+-- handlers. This covers direct gil mutations in quest/mission callbacks and
+-- continues to work when a container is reloaded.
+m:addOverride('InteractionLookup.addContainer', function(lookup, container, validZoneTable)
+    local context = contextForContainer(container)
+    if context ~= nil and not wrappedContainers[container] then
+        wrappedContainers[container] = true
+        wrapContainerTable(container.sections, context, {})
+    end
+
+    return super(lookup, container, validZoneTable)
+end)
+
+-- Legacy completion helpers can be called outside interaction containers.
+m:addOverride('npcUtil.completeQuest', function(player, area, questId, params)
+    local questLogId = type(area) == 'table' and area.quest_log or area
+    local context = {
+        mintCategory = 'quest_reward',
+        burnCategory = 'quest_fee',
+        sourceType = 'quest',
+        questLogId = questLogId,
+        questId = questId,
+    }
+
+    return withContext(player, context, super, player, area, questId, params)
+end)
+
+m:addOverride('npcUtil.completeMission', function(player, missionLogId, missionId, params)
+    local context = {
+        mintCategory = 'mission_reward',
+        burnCategory = 'quest_fee',
+        sourceType = 'mission',
+        missionLogId = missionLogId,
+        missionId = missionId,
+    }
+
+    return withContext(player, context, super, player, missionLogId, missionId, params)
+end)
+
+-- Character creation is the sole authoritative START_GIL grant. Adventurer
+-- coupon NPC rewards are ordinary scripted rewards, not starting gil.
+m:addOverride('xi.player.charCreate',
+    makeStaticOverride('starting_gil', nil, 'character-creation'))
+
+local function adminContext(player, mintCategory, burnCategory)
+    return {
+        mintCategory = mintCategory,
+        burnCategory = burnCategory,
+        sourceType = 'admin',
+        actorCharId = player:getID(),
+    }
+end
+
+m:addOverride('xi.commands.givegil.onTrigger', function(player, amount, target)
+    local recipient = target == nil and player or GetPlayerByName(target)
+    return withContext(recipient, adminContext(player, 'admin_grant', nil),
+        super, player, amount, target)
+end)
+
+m:addOverride('xi.commands.setgil.onTrigger', function(player, amount)
+    return withContext(player, adminContext(player, 'admin_grant', 'admin_remove'),
+        super, player, amount)
+end)
+
+m:addOverride('xi.commands.takegil.onTrigger', function(player, amount, target)
+    local recipient = target == nil and player or GetPlayerByName(target)
+    return withContext(recipient, adminContext(player, nil, 'admin_remove'),
+        super, player, amount, target)
+end)
+
+-- Guild shops are Lua-authoritative and expose both the NPC and item identity.
+m:addOverride('xi.guildShops.onPlayerBuy', function(player, npc, itemId, quantity)
+    local context = entitySource({
+        burnCategory = 'guild_shop_purchase',
+        sourceType = 'system',
+        systemKey = 'guild-shop',
+        serviceKey = 'guild-shop',
+        itemId = itemId,
+        itemQuantity = quantity,
+    }, npc)
+
+    return withContext(player, context, super, player, npc, itemId, quantity)
+end)
+
+m:addOverride('xi.guildShops.onPlayerSell', function(player, npc, itemId, quantity)
+    local context = entitySource({
+        mintCategory = 'guild_vendor_sale',
+        sourceType = 'system',
+        systemKey = 'guild-shop',
+        serviceKey = 'guild-shop',
+        itemId = itemId,
+        itemQuantity = quantity,
+    }, npc)
+
+    return withContext(player, context, super, player, npc, itemId, quantity)
+end)
+
+m:addOverride('xi.job_utils.thief.useMug', function(player, target, ability, action)
+    local context = entitySource({
+        mintCategory = 'mug',
+        sourceType = 'system',
+        systemKey = 'mug',
+    }, target)
+
+    return withContext(player, context, super, player, target, ability, action)
+end)
+
+m:addOverride('xi.regime.checkRegime', function(player, mob, regimeId, index, regimeType)
+    local context = {
+        mintCategory = 'regime_reward',
+        sourceType = 'regime',
+        regimeId = regimeId,
+    }
+
+    return withContext(player, context, super, player, mob, regimeId, index, regimeType)
+end)
+
+m:addOverride('Battlefield.handleLootRolls', function(battlefieldContent, battlefield, lootTable, npc, gilBonusMod)
+    local context = {
+        mintCategory = 'battlefield_reward',
+        sourceType = 'battlefield',
+        battlefieldId = battlefieldContent.battlefieldId,
+    }
+
+    return withContexts(battlefield:getPlayers(), context, super,
+        battlefieldContent, battlefield, lootTable, npc, gilBonusMod)
+end)
+
+m:addOverride('xi.chocobo.renterOnEventFinish',
+    makeStaticOverride(nil, 'chocobo_rental', 'chocobo-rental'))
+
+local transportOverrides =
+{
+    { 'xi.barge.onTicketShopEventFinish',                                      'barge-ticket' },
+    { 'xi.conquest.overseerOnEventFinish',                                     'conquest-homepoint' },
+    { 'xi.conquest.teleporterOnEventFinish',                                   'outpost-teleport' },
+    { 'xi.conquest.vendorOnEventFinish',                                       'outpost-return' },
+    { 'xi.homepoint.onEventFinish',                                             'homepoint' },
+    { 'xi.survivalGuide.onEventFinish',                                         'survival-guide' },
+    { 'xi.teleport.explorerMoogleOnEventFinish',                                'explorer-moogle' },
+    { 'xi.zones.Aht_Urhgan_Whitegate.npcs.Atiza.onEventFinish',                 'ferry-ticket' },
+    { 'xi.zones.Aht_Urhgan_Whitegate.npcs.Tazhaal.onEventFinish',               'ferry-ticket' },
+    { 'xi.zones.Bibiki_Bay.npcs.Tswe_Panipahr.onEventFinish',                   'manaclipper-ticket' },
+    { 'xi.zones.Kazham.npcs.Bhoyu_Halpatacco.onEventFinish',                    'airship' },
+    { 'xi.zones.Lower_Jeuno.npcs.Derrick.onEventUpdate',                        'airship-pass' },
+    { 'xi.zones.Lower_Jeuno.npcs.Domenic.onEventFinish',                        'battlefield-teleport' },
+    { 'xi.zones.Mhaura.npcs.Felisa.onEventFinish',                              'ferry-ticket' },
+    { 'xi.zones.Nashmau.npcs.Abihaal.onEventFinish',                            'ferry-ticket' },
+    { 'xi.zones.Newton_Movalpolos.npcs.Sleakachiq.onEventFinish',               'movalpolos-teleport' },
+    { 'xi.zones.Oldton_Movalpolos.npcs.Twinkbrix.onEventFinish',                'mineshaft-teleport' },
+    { 'xi.zones.Port_Bastok.npcs.Alib-Mufalib.onEventFinish',                   'whitegate-teleport' },
+    { 'xi.zones.Port_Bastok.npcs.Rajesh.onEventFinish',                         'airship' },
+    { 'xi.zones.Port_Bastok.npcs.Varden.onEventFinish',                         'airship' },
+    { 'xi.zones.Port_Bastok.npcs._6k8.onEventFinish',                           'airship' },
+    { 'xi.zones.Port_Jeuno.npcs.Guddal.onEventUpdate',                          'airship-pass' },
+    { 'xi.zones.Port_Jeuno.npcs.Illauvolahaut.onEventFinish',                   'airship' },
+    { 'xi.zones.Port_Jeuno.npcs.Omiro-Zamiro.onEventFinish',                    'airship' },
+    { 'xi.zones.Port_Jeuno.npcs.Purequane.onEventFinish',                       'airship' },
+    { 'xi.zones.Port_Jeuno.npcs.Zedduva.onEventFinish',                         'airship' },
+    { 'xi.zones.Port_Jeuno.npcs._6u4.onEventFinish',                            'airship' },
+    { 'xi.zones.Port_Jeuno.npcs._6u8.onEventFinish',                            'airship' },
+    { 'xi.zones.Port_Jeuno.npcs._6ua.onEventFinish',                            'airship' },
+    { 'xi.zones.Port_Jeuno.npcs._6ue.onEventFinish',                            'airship' },
+    { 'xi.zones.Port_San_dOria.npcs.Anton.onEventFinish',                       'airship' },
+    { 'xi.zones.Port_San_dOria.npcs._6g9.onEventFinish',                        'airship' },
+    { 'xi.zones.Port_Windurst.npcs.Honorio.onEventFinish',                      'airship' },
+    { 'xi.zones.Port_Windurst.npcs._6o6.onEventFinish',                         'airship' },
+    { 'xi.zones.Selbina.npcs.Lucia.onEventFinish',                              'ferry-ticket' },
+    { 'xi.zones.Southern_San_dOria.npcs.Amutiyaal.onEventFinish',               'whitegate-teleport' },
+    { 'xi.zones.Upper_Jeuno.npcs.Ajithaam.onEventFinish',                       'whitegate-teleport' },
+    { 'xi.zones.Windurst_Woods.npcs.Ibwam.onEventFinish',                       'whitegate-teleport' },
+}
+
+for _, entry in ipairs(transportOverrides) do
+    m:addOverride(entry[1], makeStaticOverride(nil, 'transport_fee', entry[2]))
+end
+
+local serviceOverrides =
+{
+    { 'xi.appraisal.appraisalOnEventFinish',                                    'appraisal' },
+    { 'xi.armorStorage.onEventFinish',                                           'armor-storage' },
+    { 'xi.artisan.moogleOnUpdate',                                               'mog-sack' },
+    { 'xi.clamming.zonikkiOnEventFinish',                                        'clamming-kit' },
+    { 'xi.crafting.oldImageSupportOnEventFinish',                                'crafting-image-support' },
+    { 'xi.dynamis.hourglassAndCurrencyExchangeNPCOnEventFinish',                 'dynamis-hourglass' },
+    { 'xi.dynamis.hourglassAndCurrencyExchangeNPCOnEventUpdate',                 'dynamis-map' },
+    { 'xi.fishingContest.onEventFinish',                                         'fishing-contest' },
+    { 'xi.linkshellConcierge.onEventFinish',                                     'linkshell-concierge' },
+    { 'xi.maps.onEventUpdate',                                                   'map-vendor' },
+    { 'xi.porter_moogle.onEventFinish',                                          'porter-moogle' },
+    { 'xi.titleChanger.onEventFinish',                                           'title-changer' },
+    { 'xi.voidwalker.npcOnEventFinish',                                          'voidwalker-abyssite' },
+    { 'xi.zones.Aht_Urhgan_Whitegate.npcs.Abda-Lurabda.onEventFinish',           'character-rename' },
+    { 'xi.zones.Bastok_Markets.npcs.Lamepaue.onEventUpdate',                     'cutscene-replay' },
+    { 'xi.zones.Heavens_Tower.npcs.Rakano-Marukano.onEventFinish',               'armor-storage' },
+    { 'xi.zones.Lower_Jeuno.npcs.Vingijard.onEventFinish',                       'artifact-reset' },
+    { 'xi.zones.Metalworks.npcs.Mythily.onEventFinish',                          'armor-storage' },
+    { 'xi.zones.Nashmau.npcs.Kilusha.onEventFinish',                             'einherjar-lamp' },
+    { 'xi.zones.Norg.npcs.Fouvia.onEventFinish',                                 'character-rename' },
+    { 'xi.zones.Northern_San_dOria.npcs.Beriphaule.onEventFinish',               'armor-storage' },
+    { 'xi.zones.Northern_San_dOria.npcs.Durogg.onEventUpdate',                   'cutscene-replay' },
+    { 'xi.zones.Oldton_Movalpolos.npcs.Twinkbrix.onTrade',                       'twinkbrix-gamble' },
+    { 'xi.zones.Port_Bastok.npcs.Dalba.onEventUpdate',                           'cutscene-replay' },
+    { 'xi.zones.Port_Jeuno.npcs.Sagheera.onEventUpdate',                         'cosmo-cleanse' },
+    { 'xi.zones.Temple_of_Uggalepih.npcs._4f3.onEventFinish',                    'tonberry-hate-reset' },
+    { 'xi.zones.Upper_Jeuno.npcs.Monberaux.onEventFinish',                       'monberaux-training' },
+}
+
+for _, entry in ipairs(serviceOverrides) do
+    m:addOverride(entry[1], makeStaticOverride(nil, 'service_fee', entry[2]))
+end
+
+-- Stage only stable mob/member evidence after the stock death callback. The
+-- native ITEM_NUM + MsgBasic::Obtains pair decides whether a correlated event,
+-- forgone mint, or attribution gap is emitted.
+m:addOverride('xi.mob.onMobDeathEx', function(mob, player, isKiller, isWeaponSkillKill)
+    local result = pack(pcall(super, mob, player, isKiller, isWeaponSkillKill))
+    if
+        player ~= nil and
+        telemetryEnabled() and
+        xi.economy.stageMobDeath ~= nil
+    then
+        xi.economy.stageMobDeath(player, mob)
+    end
+
+    if not result[1] then
+        error(result[2], 0)
+    end
+
+    return unpack(result, 2, result.n)
+end)
+
+return m

--- a/modules/phoenix/economy/tests/economy_correlator_harness.cc
+++ b/modules/phoenix/economy/tests/economy_correlator_harness.cc
@@ -1,0 +1,100 @@
+#include "economy_correlator.h"
+
+#include <cstdint>
+#include <iostream>
+#include <string_view>
+
+namespace
+{
+
+using namespace phoenix::economy::correlator;
+
+auto expect(bool condition, std::string_view message) -> bool
+{
+    if (!condition)
+    {
+        std::cerr << "FAILED: " << message << '\n';
+    }
+    return condition;
+}
+
+} // namespace
+
+auto main() -> int
+{
+    auto passed = true;
+
+    const auto debit = reconcileSingle(1000, 700, Direction::Debit);
+    passed &= expect(debit.status == Status::Complete && debit.amount == 300, "single debit success");
+    passed &= expect(reconcileSingle(1000, 1000, Direction::Debit).status == Status::NoChange,
+                     "cancel/no-delta is not an event or gap");
+    passed &= expect(reconcileSingle(1000, 1100, Direction::Debit).status == Status::Gap,
+                     "single direction mismatch becomes a gap");
+
+    passed &= expect(expiryStatus(false, 1000, 1000) == Status::NoChange,
+                     "unobserved failed attempt expires quietly");
+    passed &= expect(expiryStatus(true, 1000, 1000) == Status::NoChange,
+                     "observed zero-delta attempt expires quietly");
+    passed &= expect(expiryStatus(true, 1000, 900) == Status::Gap,
+                     "changed unconfirmed attempt expires as a gap");
+
+    ContextDepth contexts;
+    for (auto depth = 0; depth < 16; ++depth)
+    {
+        passed &= expect(beginContext(contexts, 16, true) == ContextBegin::Pushed,
+                         "bounded context accepts in-range nesting");
+    }
+    passed &= expect(beginContext(contexts, 16, true) == ContextBegin::Suppressed &&
+                         !semanticContextUsable(contexts),
+                     "depth overflow suppresses rather than reusing the outer source");
+    passed &= expect(endContext(contexts) == ContextEnd::Unsuppressed && semanticContextUsable(contexts),
+                     "overflow suppression unwinds before the outer source");
+    while (contexts.depth > 0)
+    {
+        static_cast<void>(endContext(contexts));
+    }
+    passed &= expect(beginContext(contexts, 16, true) == ContextBegin::Pushed,
+                     "outer context fixture begins");
+    passed &= expect(beginContext(contexts, 16, false) == ContextBegin::Suppressed &&
+                         !semanticContextUsable(contexts),
+                     "invalid nested context suppresses outer attribution");
+    passed &= expect(endContext(contexts) == ContextEnd::Unsuppressed && semanticContextUsable(contexts),
+                     "invalid nested context restores outer attribution after scope");
+    passed &= expect(endContext(contexts) == ContextEnd::Popped && !semanticContextUsable(contexts),
+                     "outer context pops cleanly");
+
+    const auto bazaar = reconcileBazaar(5000, 3950, 1000, 1900, 1000);
+    passed &= expect(bazaar.status == Status::Complete && bazaar.transfer == 900 && bazaar.tax == 50 &&
+                         bazaar.capLoss == 100,
+                     "bazaar transfer/tax/cap legs reconcile");
+    passed &= expect(reconcileBazaar(5000, 4500, 1000, 1900, 1000).status == Status::Gap,
+                     "bazaar incomplete buyer debit is rejected");
+
+    const auto trade = reconcileTrade(1000, 800, 2000, 2200, 300, 100);
+    passed &= expect(trade.status == Status::Complete && trade.firstToSecond == 300 &&
+                         trade.secondToFirst == 100 && trade.firstCapLoss == 0 && trade.secondCapLoss == 0,
+                     "two-party bidirectional trade reconciles");
+
+    const auto cappedTrade = reconcileTrade(1000, 700, 999999900, 999999999, 300, 0);
+    passed &= expect(cappedTrade.status == Status::Complete && cappedTrade.firstToSecond == 99 &&
+                         cappedTrade.firstCapLoss == 201,
+                     "trade cap clipping becomes an explicit cap-loss leg");
+    passed &= expect(reconcileTrade(1000, 1000, 2000, 2000, 0, 0).status == Status::NoChange,
+                     "item-only trade produces no gil event");
+    passed &= expect(reconcileTrade(1000, 950, 2000, 2000, 100, 0).status == Status::Gap,
+                     "unreconciled trade legs become a gap");
+
+    const auto partialMint = reconcileMint(1500000000ULL, 100);
+    passed &= expect(partialMint.applied == 100 && partialMint.forgone == 1499999900ULL,
+                     "over-cap requested mint retains uint32 forgone amount");
+    const auto fullyForgone = reconcileMint(1500000000ULL, 0);
+    passed &= expect(fullyForgone.applied == 0 && fullyForgone.forgone == 1500000000ULL,
+                     "fully clipped over-cap mint is represented");
+
+    if (passed)
+    {
+        std::cout << "economy correlator contract: PASS\n";
+        return 0;
+    }
+    return 1;
+}

--- a/modules/phoenix/economy/tests/economy_producer_harness.cc
+++ b/modules/phoenix/economy/tests/economy_producer_harness.cc
@@ -1,0 +1,356 @@
+#include "economy_event.h"
+#include "economy_producer.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+
+using namespace phoenix::economy;
+
+auto configFor(const std::filesystem::path& spool, std::size_t queueCapacity = 8192) -> ProducerConfig
+{
+    ProducerConfig config;
+    config.enabled = true;
+    static_cast<void>(config.producerId.assign("test-map-54001"));
+    static_cast<void>(config.contentVersion.assign("test-content-v2"));
+    static_cast<void>(config.producerVersion.assign("test-producer-1"));
+    static_cast<void>(config.spoolDirectory.assign(spool.string()));
+    config.queueCapacity                 = queueCapacity;
+    config.spoolHardCapBytes             = 32ULL * 1024ULL * 1024ULL;
+    config.spoolControlReserveBytes      = 1024ULL * 1024ULL;
+    config.flushIntervalMilliseconds     = 1000;
+    config.heartbeatIntervalMilliseconds = 30000;
+    return config;
+}
+
+auto eventFor(std::uint32_t suffix = 1) -> Event
+{
+    Event event;
+    event.occurredAtUnixNanos = unixNanosNow();
+    std::array<char, 32> transaction{};
+    const auto           length = std::snprintf(transaction.data(), transaction.size(), "test:%u", suffix);
+    static_cast<void>(event.transactionId.assign({ transaction.data(), static_cast<std::size_t>(length) }));
+    event.kind     = Kind::Mint;
+    event.category = Category::StartingGil;
+    event.amount   = 123 + suffix % 100;
+    event.toCharId.set(1000 + suffix);
+    event.sourceType = SourceType::System;
+    static_cast<void>(event.sourceKey.assign("system:character-creation"));
+    static_cast<void>(event.context.systemKey.assign("character-creation"));
+    return event;
+}
+
+void printMetrics(std::string_view scenario, const MetricsSnapshot& metrics)
+{
+    std::cout << scenario << ".enqueued=" << metrics.enqueuedEvents << '\n';
+    std::cout << scenario << ".dropped=" << metrics.droppedEvents << '\n';
+    std::cout << scenario << ".queue_overflow=" << metrics.queueOverflowEvents << '\n';
+    std::cout << scenario << ".producer_thread_violation=" << metrics.producerThreadViolationEvents << '\n';
+    std::cout << scenario << ".spool_capacity=" << metrics.spoolCapacityEvents << '\n';
+    std::cout << scenario << ".spool_write_failure=" << metrics.spoolWriteFailureEvents << '\n';
+    std::cout << scenario << ".batches=" << metrics.batchesWritten << '\n';
+}
+
+auto runBasic(const std::filesystem::path& directory) -> bool
+{
+    Producer producer;
+    auto     config = configFor(directory);
+    if (producer.start(config) != StartResult::Started)
+    {
+        return false;
+    }
+
+    const auto event                   = eventFor();
+    const auto allocationsBefore       = recordQueueAllocationCallsForCurrentThread();
+    const auto result                  = producer.tryRecord(event);
+    const auto allocationsAfter        = recordQueueAllocationCallsForCurrentThread();
+    const auto firstEnqueueAllocations = allocationsAfter - allocationsBefore;
+    std::cout << "enqueue.first_thread_allocations=" << firstEnqueueAllocations << '\n';
+    if (result != RecordResult::Enqueued || firstEnqueueAllocations != 0)
+    {
+        return false;
+    }
+
+    AttributionGap gap;
+    gap.occurredAtUnixNanos = unixNanosNow();
+    gap.charId              = 1001;
+    gap.direction           = AttributionDirection::Credit;
+    gap.appliedDelta        = 50;
+    gap.evidenceType        = EvidenceType::WalletObserver;
+    static_cast<void>(gap.sourceHint.assign("script:test"));
+    static_cast<void>(gap.detailCode.assign("unmatched-wallet-change"));
+
+    ForgoneMint forgone;
+    forgone.occurredAtUnixNanos = unixNanosNow();
+    forgone.charId              = 1001;
+    forgone.requestedAmount     = 4294967295ULL;
+    forgone.appliedAmount       = 0;
+    forgone.forgoneAmount       = 4294967295ULL;
+    forgone.category            = Category::StartingGil;
+    static_cast<void>(forgone.transactionId.assign("test:cap"));
+    forgone.sourceType = SourceType::System;
+    static_cast<void>(forgone.sourceKey.assign("system:character-creation"));
+    static_cast<void>(forgone.context.systemKey.assign("character-creation"));
+    if (producer.tryRecord(gap) != RecordResult::Enqueued || producer.tryRecord(forgone) != RecordResult::Enqueued)
+    {
+        return false;
+    }
+    producer.stop();
+    const auto metrics = producer.metrics();
+    printMetrics("basic", metrics);
+    return metrics.enqueuedEvents == 3 && metrics.droppedEvents == 0 && metrics.batchesWritten >= 2;
+}
+
+auto runImmediateStop(const std::filesystem::path& directory) -> bool
+{
+    Producer producer;
+    auto     config = configFor(directory, 32);
+    if (producer.start(config) != StartResult::Started)
+    {
+        return false;
+    }
+
+    producer.stop();
+    const auto metrics = producer.metrics();
+    printMetrics("immediate_stop", metrics);
+    return metrics.batchesWritten == 1;
+}
+
+auto runOverflow(const std::filesystem::path& directory) -> bool
+{
+    Producer producer;
+    auto     config = configFor(directory, 2);
+    if (producer.start(config) != StartResult::Started)
+    {
+        return false;
+    }
+
+    constexpr std::size_t      Iterations = 50000;
+    std::vector<std::uint64_t> timings;
+    timings.reserve(Iterations);
+    const auto event = eventFor(2);
+    for (std::size_t index = 0; index < Iterations; ++index)
+    {
+        const auto start = std::chrono::steady_clock::now();
+        static_cast<void>(producer.tryRecord(event));
+        const auto end = std::chrono::steady_clock::now();
+        timings.push_back(static_cast<std::uint64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count()));
+    }
+    producer.stop();
+
+    std::sort(timings.begin(), timings.end());
+    const auto p50 = timings[timings.size() * 50 / 100];
+    const auto p95 = timings[timings.size() * 95 / 100];
+    const auto p99 = timings[timings.size() * 99 / 100];
+    std::cout << "enqueue.p50_ns=" << p50 << '\n';
+    std::cout << "enqueue.p95_ns=" << p95 << '\n';
+    std::cout << "enqueue.p99_ns=" << p99 << '\n';
+
+    const auto metrics = producer.metrics();
+    printMetrics("overflow", metrics);
+    return metrics.queueOverflowEvents > 0 && metrics.droppedEvents >= metrics.queueOverflowEvents && p99 < 1000000;
+}
+
+auto runCapacity(const std::filesystem::path& directory) -> bool
+{
+    Producer producer;
+    auto     config                 = configFor(directory, 2048);
+    config.spoolHardCapBytes        = 4096;
+    config.spoolControlReserveBytes = 3584;
+    if (producer.start(config) != StartResult::Started)
+    {
+        return false;
+    }
+    for (std::uint32_t index = 1; index <= MaxEventsPerBatch; ++index)
+    {
+        if (producer.tryRecord(eventFor(index)) != RecordResult::Enqueued)
+        {
+            return false;
+        }
+    }
+    producer.stop();
+    const auto metrics = producer.metrics();
+    printMetrics("capacity", metrics);
+    return metrics.spoolCapacityEvents == MaxEventsPerBatch && metrics.droppedEvents == MaxEventsPerBatch &&
+           metrics.batchesWritten >= 1;
+}
+
+auto runWriteFailure(const std::filesystem::path& directory) -> bool
+{
+    {
+        std::ofstream blocker(directory);
+        blocker << "not-a-directory";
+    }
+
+    Producer producer;
+    auto     config                  = configFor(directory, 32);
+    config.flushIntervalMilliseconds = 10;
+    if (producer.start(config) != StartResult::Started || producer.tryRecord(eventFor(9)) != RecordResult::Enqueued)
+    {
+        return false;
+    }
+
+    for (auto attempt = 0; attempt < 200 && producer.metrics().spoolWriteFailureEvents == 0; ++attempt)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    if (producer.metrics().spoolWriteFailureEvents == 0 || !std::filesystem::remove(directory))
+    {
+        producer.stop();
+        return false;
+    }
+    std::filesystem::create_directories(directory);
+    producer.stop();
+
+    const auto metrics = producer.metrics();
+    printMetrics("write_failure", metrics);
+    return metrics.spoolWriteFailureEvents == 1 && metrics.droppedEvents == 1 && metrics.batchesWritten >= 1;
+}
+
+auto runProducerThreadInvariant(const std::filesystem::path& directory) -> bool
+{
+    Producer producer;
+    auto     config = configFor(directory, 32);
+    if (producer.start(config) != StartResult::Started)
+    {
+        return false;
+    }
+
+    auto        result = RecordResult::Disabled;
+    std::thread offThread([&producer, &result]
+                          {
+                              result = producer.tryRecord(eventFor(77));
+                          });
+    offThread.join();
+    producer.stop();
+
+    const auto metrics = producer.metrics();
+    printMetrics("thread_invariant", metrics);
+    return result == RecordResult::InvalidEvent && metrics.enqueuedEvents == 0 && metrics.droppedEvents == 1 &&
+           metrics.producerThreadViolationEvents == 1 && metrics.batchesWritten >= 1;
+}
+
+auto runGameTickHeartbeat(const std::filesystem::path& directory) -> bool
+{
+    Producer producer;
+    auto     config                      = configFor(directory, 32);
+    config.flushIntervalMilliseconds     = 10;
+    config.heartbeatIntervalMilliseconds = 20;
+    if (producer.start(config) != StartResult::Started)
+    {
+        return false;
+    }
+
+    producer.noteGameTick();
+    for (auto attempt = 0; attempt < 250 && producer.metrics().batchesWritten == 0; ++attempt)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    const auto afterFirstTick = producer.metrics().batchesWritten;
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(80));
+    const auto afterStall = producer.metrics().batchesWritten;
+
+    producer.noteGameTick();
+    for (auto attempt = 0; attempt < 250 && producer.metrics().batchesWritten == afterStall; ++attempt)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    const auto afterSecondTick = producer.metrics().batchesWritten;
+    producer.stop();
+
+    std::cout << "heartbeat.after_first_tick=" << afterFirstTick << '\n';
+    std::cout << "heartbeat.after_stall=" << afterStall << '\n';
+    std::cout << "heartbeat.after_second_tick=" << afterSecondTick << '\n';
+    printMetrics("heartbeat", producer.metrics());
+    return afterFirstTick > 0 && afterStall == afterFirstTick && afterSecondTick > afterStall;
+}
+
+auto runControlBounds(const std::filesystem::path& directory) -> bool
+{
+    Producer producer;
+    auto     config = configFor(directory, 1024);
+    if (producer.start(config) != StartResult::Started)
+    {
+        return false;
+    }
+
+    for (std::uint32_t index = 1; index <= 150; ++index)
+    {
+        AttributionGap gap;
+        gap.occurredAtUnixNanos = unixNanosNow();
+        gap.charId              = 2000 + index;
+        gap.direction           = AttributionDirection::Debit;
+        gap.appliedDelta        = index;
+        gap.evidenceType        = EvidenceType::WalletObserver;
+        static_cast<void>(gap.detailCode.assign("control-bound-test"));
+        if (producer.tryRecord(gap) != RecordResult::Enqueued)
+        {
+            return false;
+        }
+    }
+    for (std::uint32_t index = 1; index <= 150; ++index)
+    {
+        ForgoneMint diagnostic;
+        diagnostic.occurredAtUnixNanos = unixNanosNow();
+        diagnostic.charId              = 3000 + index;
+        diagnostic.requestedAmount     = index + 1;
+        diagnostic.appliedAmount       = index;
+        diagnostic.forgoneAmount       = 1;
+        diagnostic.category            = Category::StartingGil;
+        static_cast<void>(diagnostic.transactionId.assign("control-bound:test"));
+        diagnostic.sourceType = SourceType::System;
+        static_cast<void>(diagnostic.sourceKey.assign("system:character-creation"));
+        static_cast<void>(diagnostic.context.systemKey.assign("character-creation"));
+        if (producer.tryRecord(diagnostic) != RecordResult::Enqueued)
+        {
+            return false;
+        }
+    }
+    producer.stop();
+    const auto metrics = producer.metrics();
+    printMetrics("control_bounds", metrics);
+    return metrics.enqueuedEvents == 300 && metrics.droppedEvents == 0 && metrics.batchesWritten >= 3;
+}
+
+} // namespace
+
+auto main(int argc, char** argv) -> int
+{
+    if (argc != 2)
+    {
+        std::cerr << "usage: economy_producer_harness <empty-output-directory>\n";
+        return 2;
+    }
+
+    const auto root = std::filesystem::absolute(argv[1]);
+    if (std::filesystem::exists(root) && !std::filesystem::is_empty(root))
+    {
+        std::cerr << "refusing to use a non-empty test output directory\n";
+        return 2;
+    }
+    std::filesystem::create_directories(root);
+
+    const auto basic           = runBasic(root / "basic");
+    const auto immediateStop   = runImmediateStop(root / "immediate-stop");
+    const auto overflow        = runOverflow(root / "overflow");
+    const auto capacity        = runCapacity(root / "capacity");
+    const auto writeFailure    = runWriteFailure(root / "write-failure");
+    const auto threadInvariant = runProducerThreadInvariant(root / "thread-invariant");
+    const auto heartbeat       = runGameTickHeartbeat(root / "heartbeat");
+    const auto controlBounds   = runControlBounds(root / "control-bounds");
+    return basic && immediateStop && overflow && capacity && writeFailure && threadInvariant && heartbeat &&
+                   controlBounds
+               ? 0
+               : 1;
+}

--- a/modules/phoenix/economy/tests/test_lua_overrides.luatest
+++ b/modules/phoenix/economy/tests/test_lua_overrides.luatest
@@ -1,0 +1,206 @@
+-- Standalone LuaJIT contract fixture; the non-.lua suffix keeps module loaders from executing it.
+local modulePath = assert(arg[1], 'module path is required')
+
+package.loaded['modules/module_utils'] = true
+
+Module = {}
+function Module:new(name)
+    return { name = name, overrides = {}, addOverride = self.addOverride }
+end
+
+function Module:addOverride(name, func)
+    table.insert(self.overrides, { name = name, func = func })
+end
+
+local contextStacks = setmetatable({}, { __mode = 'k' })
+local records = {}
+local captures = 0
+local mobStages = 0
+
+xi = {
+    economy = {},
+}
+
+function xi.economy.enabled()
+    return true
+end
+
+function xi.economy.beginContext(player, context)
+    local stack = contextStacks[player] or {}
+    contextStacks[player] = stack
+    table.insert(stack, context)
+    return true
+end
+
+function xi.economy.endContext(player)
+    local stack = assert(contextStacks[player])
+    table.remove(stack)
+end
+
+function xi.economy.beginLuaWallet(_)
+    return true
+end
+
+function xi.economy.endLuaWallet(player, before, after, requested, operation)
+    local stack = contextStacks[player] or {}
+    table.insert(records, {
+        player = player,
+        before = before,
+        after = after,
+        requested = requested,
+        operation = operation,
+        context = stack[#stack],
+    })
+end
+
+function xi.economy.captureShop(_)
+    captures = captures + 1
+end
+
+function xi.economy.stageMobDeath(_, _)
+    mobStages = mobStages + 1
+end
+
+local playersByName = {}
+function GetPlayerByName(name)
+    return playersByName[name]
+end
+
+local module = assert(dofile(modulePath))
+
+local function override(name)
+    for _, entry in ipairs(module.overrides) do
+        if entry.name == name then
+            return entry.func
+        end
+    end
+
+    error('missing override: ' .. name)
+end
+
+local function installSuper(func, superFunc)
+    local env = { super = superFunc }
+    setmetatable(env, { __index = getfenv(func) })
+    setfenv(func, env)
+    return func
+end
+
+local function expect(condition, message)
+    if not condition then
+        error('FAILED: ' .. message, 0)
+    end
+end
+
+local function player(id, gil)
+    local result = { id = id, gil = gil }
+    function result:getID()
+        return self.id
+    end
+
+    function result:getGil()
+        return self.gil
+    end
+
+    return result
+end
+
+local addGil = installSuper(override('CBaseEntity.addGil'), function(target, amount)
+    target.gil = math.min(999999999, target.gil + amount)
+end)
+
+local delGil = installSuper(override('CBaseEntity.delGil'), function(target, amount)
+    if amount > target.gil then
+        return false
+    end
+
+    target.gil = target.gil - amount
+    return true
+end)
+
+local gm = player(1001, 500)
+local recipient = player(2002, 100)
+playersByName.Recipient = recipient
+
+local givegil = installSuper(override('xi.commands.givegil.onTrigger'), function(actor, amount, targetName)
+    local target = targetName == nil and actor or GetPlayerByName(targetName)
+    addGil(target, amount)
+end)
+
+givegil(gm, 250, 'Recipient')
+local giveRecord = records[#records]
+expect(giveRecord.player == recipient, 'givegil context follows the named recipient')
+expect(giveRecord.context.sourceType == 'admin' and giveRecord.context.actorCharId == gm.id,
+    'givegil retains the invoking GM as actor')
+expect(giveRecord.context.mintCategory == 'admin_grant', 'givegil category is admin_grant')
+
+local takegil = installSuper(override('xi.commands.takegil.onTrigger'), function(actor, amount, targetName)
+    local target = targetName == nil and actor or GetPlayerByName(targetName)
+    delGil(target, amount)
+end)
+
+takegil(gm, 50, 'Recipient')
+local takeRecord = records[#records]
+expect(takeRecord.player == recipient, 'takegil context follows the named recipient')
+expect(takeRecord.context.actorCharId == gm.id and takeRecord.context.burnCategory == 'admin_remove',
+    'takegil retains admin actor/removal semantics')
+
+local first = player(3003, 0)
+local second = player(4004, 10)
+local battlefield = {}
+function battlefield:getPlayers()
+    return { first, second }
+end
+
+local battlefieldLoot = installSuper(override('Battlefield.handleLootRolls'),
+    function(_, field, _, _, _)
+        for _, member in ipairs(field:getPlayers()) do
+            addGil(member, 25)
+        end
+    end)
+local recordStart = #records
+battlefieldLoot({ battlefieldId = 63 }, battlefield, {}, nil, 1)
+expect(#records == recordStart + 2, 'battlefield reward observes every player')
+expect(records[recordStart + 1].context.battlefieldId == 63 and
+    records[recordStart + 2].context.battlefieldId == 63,
+    'battlefield context is active for every rewarded player')
+
+local nested = player(5005, 0)
+local mission = installSuper(override('npcUtil.completeMission'), function(target, _, _, _)
+    addGil(target, 5)
+end)
+
+local quest = installSuper(override('npcUtil.completeQuest'), function(target, _, _, _)
+    mission(target, 4, 9, {})
+    addGil(target, 7)
+end)
+
+recordStart = #records
+quest(nested, 2, 37, {})
+expect(records[recordStart + 1].context.sourceType == 'mission', 'inner context wins while nested')
+expect(records[recordStart + 2].context.sourceType == 'quest', 'outer context is restored after nested call')
+
+local capped = player(6006, 999999900)
+xi.economy.beginContext(capped, {
+    mintCategory = 'script_reward',
+    sourceType = 'system',
+    systemKey = 'cap-fixture',
+})
+addGil(capped, 1500000000)
+xi.economy.endContext(capped)
+local capRecord = records[#records]
+expect(capRecord.after - capRecord.before == 99, 'wallet override records applied cap-clipped credit')
+expect(capRecord.requested == 1500000000, 'wallet override preserves over-cap requested amount')
+
+local createShop = installSuper(override('CBaseEntity.createShop'), function(_, _)
+end)
+
+createShop(gm, 4)
+expect(captures == 1, 'createShop captures native menu attribution after super')
+
+local mobDeath = installSuper(override('xi.mob.onMobDeathEx'), function(_, _, _, _)
+end)
+
+mobDeath({}, first, true, false)
+expect(mobStages == 1, 'mob death stages correlated evidence after super')
+
+print('economy Lua override contract: PASS')

--- a/modules/phoenix/economy/tests/test_spool_contract.py
+++ b/modules/phoenix/economy/tests/test_spool_contract.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Exercise the production producer and independently validate its spool contract."""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import json
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+FILE_NAME = re.compile(
+    r"^economy-(?P<started>[0-9]{13})-[0-9a-f-]{36}-(?P<sequence>[0-9]{20})\.json\.gz$"
+)
+
+
+def canonical(value: object) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()
+
+
+def load_batches(directory: Path) -> list[dict[str, object]]:
+    assert not list(directory.glob("*.tmp")), f"temporary files survived atomic completion in {directory}"
+    files = sorted(directory.glob("*.json.gz"))
+    assert files, f"no completed batches in {directory}"
+    assert all(FILE_NAME.fullmatch(path.name) for path in files)
+
+    batches: list[dict[str, object]] = []
+    for path in files:
+        raw = gzip.decompress(path.read_bytes())
+        assert len(raw) <= 1024 * 1024
+        batch = json.loads(raw)
+        checksum = batch.pop("checksum")
+        assert checksum == hashlib.sha256(canonical(batch)).hexdigest(), path
+        assert batch["schemaVersion"] == 2
+        assert batch["eventCount"] == len(batch["events"])
+        assert batch["controlCount"] == len(batch["attributionGaps"]) + len(batch["forgoneMints"])
+        assert batch["eventCount"] + batch["controlCount"] <= 500
+        assert len(batch["attributionGaps"]) <= 100
+        assert len(batch["forgoneMints"]) <= 100
+        control_sequences = sorted(
+            int(control["controlSeq"])
+            for control in [*batch["attributionGaps"], *batch["forgoneMints"]]
+        )
+        if control_sequences:
+            assert int(batch["firstControlSeq"]) == control_sequences[0]
+            assert int(batch["lastControlSeq"]) == control_sequences[-1]
+        else:
+            assert batch["firstControlSeq"] is None
+            assert batch["lastControlSeq"] is None
+        batches.append(batch)
+    return batches
+
+
+def parse_metrics(output: str) -> dict[str, int]:
+    metrics: dict[str, int] = {}
+    for line in output.splitlines():
+        key, value = line.split("=", 1)
+        metrics[key] = int(value)
+    return metrics
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--harness", required=True, type=Path)
+    args = parser.parse_args()
+
+    with tempfile.TemporaryDirectory(prefix="phoenix-economy-test-") as temporary:
+        root = Path(temporary)
+        result = subprocess.run(
+            [str(args.harness.resolve()), str(root)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        metrics = parse_metrics(result.stdout)
+        assert metrics["enqueue.first_thread_allocations"] == 0
+
+        basic = load_batches(root / "basic")
+        basic_events = [event for batch in basic for event in batch["events"]]
+        assert len(basic_events) == 1
+        assert basic_events[0]["contentVersion"] == "test-content-v2"
+        assert basic_events[0]["attributionQuality"] == "semantic"
+        assert basic_events[0]["evidenceVersion"] == "test-producer-1"
+        assert basic_events[0]["context"] == {"systemKey": "character-creation"}
+        assert basic_events[0]["sourceKey"] == "system:character-creation"
+        basic_attribution_gaps = [gap for batch in basic for gap in batch["attributionGaps"]]
+        basic_forgone = [diagnostic for batch in basic for diagnostic in batch["forgoneMints"]]
+        assert len(basic_attribution_gaps) == 1
+        assert basic_attribution_gaps[0]["appliedDelta"] == "50"
+        assert basic_attribution_gaps[0]["evidenceType"] == "wallet_observer"
+        assert len(basic_forgone) == 1
+        assert basic_forgone[0]["forgoneAmount"] == "4294967295"
+        assert basic_forgone[0]["requestedAmount"] == "4294967295"
+        assert basic_forgone[0]["appliedAmount"] == "0"
+        assert any(batch["controlCount"] == 2 for batch in basic)
+        assert basic[-1]["finalWatermark"] is True
+
+        immediate_stop = load_batches(root / "immediate-stop")
+        assert len(immediate_stop) == 1
+        assert immediate_stop[0]["finalWatermark"] is True
+        assert immediate_stop[0]["watermarkThrough"] > "2020-01-01T00:00:00.000Z"
+
+        overflow = load_batches(root / "overflow")
+        overflow_gaps = [gap for batch in overflow for gap in batch["gaps"]]
+        assert any(gap["reason"] == "queue_overflow" for gap in overflow_gaps)
+        assert max(int(batch["droppedEvents"]) for batch in overflow) == metrics["overflow.dropped"]
+        assert metrics["overflow.queue_overflow"] > 0
+        assert metrics["enqueue.p99_ns"] < 1_000_000
+
+        capacity = load_batches(root / "capacity")
+        capacity_gaps = [gap for batch in capacity for gap in batch["gaps"]]
+        assert any(gap["reason"] == "spool_capacity" for gap in capacity_gaps)
+        assert metrics["capacity.spool_capacity"] == 500
+        assert sum(path.stat().st_size for path in (root / "capacity").iterdir()) <= 4096
+
+        write_failure = load_batches(root / "write-failure")
+        write_failure_gaps = [gap for batch in write_failure for gap in batch["gaps"]]
+        assert any(gap["reason"] == "spool_write_failure" for gap in write_failure_gaps)
+        assert metrics["write_failure.spool_write_failure"] == 1
+
+        thread_invariant = load_batches(root / "thread-invariant")
+        thread_gaps = [gap for batch in thread_invariant for gap in batch["gaps"]]
+        assert any(gap["reason"] == "sequence_discontinuity" for gap in thread_gaps)
+        assert metrics["thread_invariant.producer_thread_violation"] == 1
+
+        heartbeat = load_batches(root / "heartbeat")
+        quiet_heartbeats = [
+            batch
+            for batch in heartbeat
+            if not batch["finalWatermark"]
+            and batch["eventCount"] == 0
+            and batch["controlCount"] == 0
+            and not batch["gaps"]
+        ]
+        assert metrics["heartbeat.after_first_tick"] == metrics["heartbeat.after_stall"]
+        assert metrics["heartbeat.after_second_tick"] > metrics["heartbeat.after_stall"]
+        assert len(quiet_heartbeats) == 2
+        assert quiet_heartbeats[0]["watermarkThrough"] < quiet_heartbeats[1]["watermarkThrough"]
+
+        control_bounds = load_batches(root / "control-bounds")
+        assert sum(batch["controlCount"] for batch in control_bounds) == 300
+        assert sum(len(batch["attributionGaps"]) for batch in control_bounds) == 150
+        assert sum(len(batch["forgoneMints"]) for batch in control_bounds) == 150
+
+        print(result.stdout, end="")
+        print(
+            "validated_batches="
+            f"{len(basic) + len(immediate_stop) + len(overflow) + len(capacity) + len(write_failure) + len(thread_invariant) + len(heartbeat) + len(control_bounds)}"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the Contributing Guide and the Code of Conduct.
- [ ] I have tested my code and the things my code has changed since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This draft adds semantic gil telemetry as one independently enabled Phoenix module: `modules/phoenix/economy/**` plus one `modules/init.txt` entry. It does not patch LandSandBoat `src/**`, `scripts/**`, SQL, or core settings.

The producer is disabled by default. This PR does not deploy or enable it in beta or production. The companion schema-v2 API draft is [phoenix-api#62](https://github.com/phoenixffxi/phoenix-api/pull/62).

## Architecture and data flow

`authoritative Lua/native transaction -> fixed-size record -> bounded tokenized MPSC queue -> background validator/sequencer -> canonical JSON + SHA-256 -> durable gzip spool -> separate forwarder -> API/PostgreSQL`

- The map/game thread performs fixed-size copies and tokenized `try_enqueue` only. It performs no network, database, JSON, compression, or filesystem work.
- Startup preallocates an 8,192-record queue and its sole explicit producer token. Tokenless/implicit producers are disabled; off-thread producer calls are rejected, counted, and reported as sequence gaps.
- A background worker validates records, batches at most 500 combined records (and at most 100 of either control type), hashes/compresses them, and writes temp -> flush/fsync -> atomic rename -> directory fsync.
- Default spool hard cap is 256 MiB with a 1 MiB control reserve. Queue overflow, invalid records, write failures, capacity loss, and attribution ambiguity increment counters and generate explicit controls.
- Startup seeds a conservative map-thread watermark floor. Later quiet heartbeats advance only after `OnTimeServerTick`; a stalled game loop cannot manufacture continuing progress.
- Lua overrides call `super`, preserve return values/errors, and synchronously unwind semantic context. With the enable flag unset/false, the Lua file returns before loading module utilities or registering overrides.
- `OnIncomingPacket` is observation-only, always returns `false`, and never calls `packet.process`; core retains transaction ownership.

## Instrumented transaction points

Semantic Lua before/after attribution:

- Base `addGil`, `delGil`, `setGil`, `confirmTrade`, and `tradeComplete` bindings, covering all Lua callers through one module seam.
- `InteractionLookup` quest/mission containers and `npcUtil.completeQuest` / `completeMission`.
- Starting gil; GM give/take/set (including correctly scoped named targets); guild-shop buy/sell; Mug; regimes; all battlefield members; chocobo rental.
- 38 explicitly audited transport handlers and 27 explicitly audited service handlers.
- `createShop` captures stable active-NPC identity for the later native shop packet.

Version-pinned, non-consuming native correlation:

- Normal shop buy: C2S `0x083` + wallet `ITEM_NUM` debit + S2C shop success.
- Normal shop sell: C2S `0x085` + wallet credit + S2C item result; clipped mint emits applied value plus `forgoneMint`.
- Bazaar: C2S `0x106` + both wallet legs + success result -> base transfer, tax burn, and any currency-cap loss.
- Completed player trade: second locked C2S `0x033` + both wallet legs + both S2C `0x022` end results; canceled/failed trades emit no event.
- AH listing: C2S `0x04e` LotIn + wallet debit + S2C listing success -> listing-fee burn.
- Monster gil: post-`onMobDeathEx` stable mob/member stage + wallet `ITEM_NUM` + S2C `0x029` Obtains -> correlated applied drop/forgone mint or an explicit gap.

Direct-mutation audit also covered AH bid debit, delivery escrow/claim/return, item movement, native monster distribution, shops, bazaar, and trade. AH sale remains owned by the existing replica lane to prevent double counting; delivery lacks a reliable after-commit seam. Unmatched wallet deltas become `attributionGaps`, never guessed `other_*` accounting events.

## Semantic coverage matrix

| Category/flow | Coverage | Evidence and boundary |
|---|---|---|
| `mug` | Full at authoritative helper | Semantic mob spawn/pool/zone + applied before/after |
| Normal/guild shop buy and sell | Full at listed paths | Semantic guild helpers; correlated native request/result/wallet proof |
| `starting_gil`, `admin_grant`, `admin_remove` | Full | Semantic central helper/command context; numeric actors only |
| `regime_reward`, standard `battlefield_reward` | Full at central helpers | Semantic regime/battlefield IDs + applied delta |
| `bazaar_sale`, `bazaar_tax` | Full at completed bazaar path | Both wallet legs and success must reconcile |
| `player_trade` | Full at completed trade path | Both participants/results reconcile; canceled/failed excluded |
| `auction_listing_fee` | Full | Listing success + applied wallet debit |
| `chocobo_rental` | Full at central rental helper | NPC/service context + applied debit |
| `mob_drop` | Partial/correlated | Version-sensitive death/wallet/obtains ordering; ambiguity is a gap |
| `quest_reward`, `mission_reward`, `quest_fee` | Partial | Central helpers/interaction containers covered; legacy leaf scripts may lack typed context |
| `transport_fee` | Partial | 38 audited handlers; unlisted/custom paths become gaps |
| `service_fee` | Partial | 27 audited handlers; unlisted/custom paths become gaps |
| `currency_cap_loss` | Partial | Proven bazaar/trade cap loss covered; other cap paths remain diagnostics |
| `auction_sale` | Existing replica lane only | Exact gross/seller is not duplicated by this producer; stable buyer attribution unavailable |
| `delivery_box` | Unsupported | No module after-commit seam proves escrow durability/conservation |
| `script_reward`, `other_mint`, `other_burn`, `other_transfer` | Intentionally unsupported | Unknown mutations are controls/gaps, not fabricated totals |
| Offline/direct database mutation | Unsupported | Outside the map module; reconciliation must detect supply mismatch |

## Performance and backpressure evidence

- First gameplay enqueue queue allocations: **0**.
- Windows Release harness: enqueue p50 **0 ns**, p95 **100 ns**, p99 **100 ns**.
- A 50,000-attempt overflow scenario remained non-blocking; 49,456 rejected records were counted and represented by an explicit queue-overflow gap in that run.
- Simulated 80 ms map stall: heartbeat batch count remained **1 -> 1**; the next map tick advanced it to **2**.
- Hard-cap scenario counted 500 capacity drops; unwritable-spool scenario counted one write failure; off-thread scenario counted/reported one producer-thread violation.
- 16 independently decoded gzip batches passed size, checksum, sequence, batch/control-bound, atomic-completion, final-watermark, and gap assertions.
- Live beta map-tick/CPU/memory/backlog baselines remain mandatory rollout gates; synthetic enqueue timing is not a substitute for the soak.

## Test results

- Full MSVC 19.44 RelWithDebInfo `xi_map` configure/build/link — passed.
- Standalone CTest — 3/3 passed: producer/spool contract, correlator contract, Lua override contract.
- `clang-format` 22.1 dry run and C++ sanity checks — passed.
- Runtime and fixture Lua style checks; disabled-Lua guard — passed.
- Module loader audit — exactly one runtime `.lua`; the test fixture uses `.luatest` and is not recursively executed.
- `git diff --check` — passed.
- Companion API: 36/36 focused economy tests and 26/26 fresh-migration ingest integration tests passed; both TypeScript type-checks and OpenAPI check passed.

## Security and privacy considerations

- No HTTP, network, MariaDB, or other database access exists in the module producer.
- API credentials belong only to the separate least-privilege forwarder, never `xi_map`.
- Payloads contain numeric character/content IDs and bounded canonical evidence tokens. They contain no character names, chat, or free-form script text.
- Spool files must live outside served paths with directory mode 0750/file mode 0640 and a dedicated ownership boundary.
- Every `xi_map` requires a unique producer ID and spool directory. The current flat-directory forwarder design requires one service instance per map spool.

## Beta rollout sequence

1. Review/merge [phoenix-api#62](https://github.com/phoenixffxi/phoenix-api/pull/62) to `beta`, apply migration 0027, and verify API health with no producer credential or game producer enabled.
2. Before updating the current beta host, preserve/reconcile its existing host-local helper scripts and `modules/init.txt` change; do not overwrite unrelated work.
3. Review/merge this PR to `beta`, build, and restart beta with `PHOENIX_ECONOMY_TELEMETRY_ENABLED` unset/false. Verify the current single `xi_map` has no producer thread/spool/Lua overrides and establish disabled tick/CPU baselines.
4. Create `/var/lib/phoenix-economy/xi_map-54230/spool`, owned by the game/forwarder principals with 0750 directory and 0640 files; enforce the 256 MiB budget.
5. Install one forwarder service for the current one-map beta topology, pointed only at that spool, but keep it disabled.
6. Create a beta-world-only `economy:ingest:beta` key and store it only in the forwarder environment. Configure endpoint, poll/timeout, and producer settings; keep producer and forwarder disabled.
7. Start the forwarder first and validate idle/authentication behavior plus a synthetic spool fixture.
8. During a maintenance restart, set the beta canary's enable flag true with unique producer ID, Phoenix commit as `CONTENT_VERSION`, and its spool path. Do not change production.
9. Exercise shop, guild, bazaar, trade, AH listing, mob, quest/mission, admin, chocobo, transport, and service cases. Verify tick-backed heartbeat, checksums/sequences, ack/delete behavior, zero MariaDB telemetry QPS, and zero unexplained drops.
10. Run a hidden seven-day soak; monitor map tick p50/p95/p99, CPU/memory, queue drops/gaps, spool/backlog, API latency, and replica-ledger reconciliation.
11. Drill API outage, forwarder restart, duplicate retry, map restart, unwritable/full spool, burst overflow, and recovery before staff sign-off.
12. Production remains disabled until a separate promotion decision. A future multi-map beta needs one unique spool + forwarder instance per map, or a forwarder multi-directory enhancement.

## Rollback procedure

Unset/set `PHOENIX_ECONOMY_TELEMETRY_ENABLED=false` and gracefully restart the beta canary so it attempts a final watermark. Stop expansion; let the forwarder drain only API-acknowledged files, preserve unacknowledged spool files for diagnosis, then stop/disable the forwarder if needed. Roll back to the prior `xi_map` binary only if required. The additive API schema can remain; do not drop it during an incident. No gameplay MariaDB reversal is involved.

## Remaining gaps and risks

- Packet layouts and result ordering are version-pinned and need beta live-trace validation.
- Fixed limits are 2,048 tracked characters, context depth 16, and four pending native operations per character; overflow/expiry becomes explicit gaps.
- AH buyer identity, delivery-box exact transfer, arbitrary offline mutations, and deliberately untyped `other_*` events are unsupported.
- Source catalog generation/storage, display-name mapping, source read endpoints, and dashboard drill-down are follow-up work.
- No deterministic `CPPModule::OnShutdown` hook exists; `atexit` final watermark is best effort and crashes remain conservatively visible as unclean boots.
- One flat spool directory cannot be shared safely by multiple `xi_map` processes.

## Steps to test these changes

```sh
cmake -S modules/phoenix/economy -B build/economy-producer-tests
cmake --build build/economy-producer-tests --config Release
ctest --test-dir build/economy-producer-tests -C Release --output-on-failure
```

Also build the full `xi_map` target, run the repository C++/Lua formatting checks, and test once with `PHOENIX_ECONOMY_TELEMETRY_ENABLED` unset to confirm no Lua overrides or spool worker are activated.
