### PR TITLE
[sql][module] Allow Nomad Moogles in ToAU era

### DIFF
--- a/modules/phoenix/sql/nomad_moogle.sql
+++ b/modules/phoenix/sql/nomad_moogle.sql
@@ -1,0 +1,8 @@
+-- ------------------------------------------------------------
+-- Sets content tags for Nomad Moogles to be available on Phoenix
+-- ------------------------------------------------------------
+
+UPDATE `npc_list` SET `content_tag` = 'TOAU' WHERE `npcid` = 17797251; -- Mhaura
+UPDATE `npc_list` SET `content_tag` = 'TOAU' WHERE `npcid` = 17797252; -- Mhaura
+UPDATE `npc_list` SET `content_tag` = 'TOAU' WHERE `npcid` = 17793129; -- Selbina
+UPDATE `npc_list` SET `content_tag` = 'TOAU' WHERE `npcid` = 17793130; -- Selbina


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- We are purposely allowing Nomad Moogles early on Phoenix for Selbina and Mhaura, which are usually available in the WotG era.