### PR TITLE
[lua][module] Level Sync Penalty Module

### DIFF
--- a/modules/phoenix/cpp/player_count.cpp
+++ b/modules/phoenix/cpp/player_count.cpp
@@ -1,0 +1,33 @@
+/************************************************************************
+ *
+ * Phoenix Population-Based Level Sync Penalty Module
+ *
+ * This module provides a C++ function to query online player count
+ * and exposes it to Lua for use in the penalty calculation system.
+ *
+ ************************************************************************/
+
+#include "common/database.h"
+#include "common/lua.h"
+#include "map/utils/moduleutils.h"
+
+class PopulationSyncPenaltyModule : public CPPModule
+{
+public:
+    void OnInit() override
+    {
+        // Counts sessions, so stale rows after a crash can inflate the number
+        lua.set_function("GetOnlinePlayerCount", []() -> uint32
+                         {
+                             auto rset = db::preparedStmt("SELECT COUNT(*) AS count FROM accounts_sessions");
+                             if (rset && rset->next())
+                             {
+                                 return rset->get<uint32>("count");
+                             }
+
+                             return 0;
+                         });
+    }
+};
+
+REGISTER_CPP_MODULE(PopulationSyncPenaltyModule);

--- a/modules/phoenix/lua/level_sync_penalty.lua
+++ b/modules/phoenix/lua/level_sync_penalty.lua
@@ -1,0 +1,139 @@
+-----------------------------------
+-- Phoenix Level Sync Penalty Module
+-- Applies EXP penalties based on server population and level sync difference
+-----------------------------------
+require('modules/module_utils')
+require('scripts/globals/npc_util')
+-----------------------------------
+-- luacheck: globals GetOnlinePlayerCount
+-----------------------------------
+local m = Module:new('population_level_sync_penalty')
+
+-- Configuration (Launch values to be determined at a later date)
+local graceLevels  = 10 -- No penalty within this many levels of sync target
+local maxPenalty   = 50 -- Maximum penalty percentage
+
+-- Population thresholds and penalty rates
+local penaltyTiers =
+{
+    { threshold = 500,       rate = 0 },  -- Below 500: no penalty
+    { threshold = 1000,      rate = 15 }, -- 500-999:   1.5% per level
+    { threshold = 2000,      rate = 20 }, -- 1000-1999: 2.0% per level
+    { threshold = math.huge, rate = 25 }, -- 2000+:     2.5% per level
+}
+
+local function updatePenaltyRate()
+    -- Guard for builds missing the paired cpp module
+    if type(GetOnlinePlayerCount) ~= 'function' then
+        return
+    end
+
+    local playerCount = GetOnlinePlayerCount()
+    local penaltyPerLevel = 0
+
+    for i = 1, #penaltyTiers do
+        if playerCount < penaltyTiers[i].threshold then
+            penaltyPerLevel = penaltyTiers[i].rate
+            break
+        end
+    end
+
+    SetServerVariable('[SyncPenalty]RatePerLevel', penaltyPerLevel)
+end
+
+local function calculatePenalty(player)
+    if not player then
+        return 0
+    end
+
+    if not player:hasStatusEffect(xi.effect.LEVEL_SYNC) then
+        return 0
+    end
+
+    -- Get player's actual level and current synced level
+    local actualLevel = player:getJobLevel(player:getMainJob())
+    local syncLevel = player:getMainLvl()
+    local levelDiff = actualLevel - syncLevel
+
+    if levelDiff <= graceLevels then
+        return 0
+    end
+
+    local penaltyPerLevel = GetServerVariable('[SyncPenalty]RatePerLevel')
+    if penaltyPerLevel == 0 then
+        return 0
+    end
+
+    -- Calculate total penalty (grace levels count once the penalty kicks in)
+    local totalPenalty = (levelDiff * penaltyPerLevel) / 10
+    totalPenalty = math.min(totalPenalty, maxPenalty)
+
+    return math.floor(totalPenalty)
+end
+
+local function removePenalty(player)
+    local penaltyAmount = player:getLocalVar('[SyncPenalty]Amount')
+
+    if penaltyAmount > 0 then
+        player:addMod(xi.mod.EXP_BONUS, penaltyAmount)
+        player:setLocalVar('[SyncPenalty]Amount', 0)
+    end
+end
+
+-- Determines and applies the appropriate penalty to level synced player
+local function applyPenalty(player)
+    removePenalty(player)
+
+    local penaltyValue = calculatePenalty(player)
+
+    if penaltyValue == 0 then
+        return
+    end
+
+    player:setLocalVar('[SyncPenalty]Amount', penaltyValue)
+    player:delMod(xi.mod.EXP_BONUS, penaltyValue)
+end
+
+-- Set the penalty rate on startup
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    updatePenaltyRate()
+end)
+
+-- Update penalty tiers every Vana'diel day, triggered once in GM Home zone file
+-- Players already synced keep their old penalty until they level up, zone, or re-sync
+m:addOverride('xi.zones.GM_Home.Zone.onGameDay', function()
+    super()
+
+    updatePenaltyRate()
+end)
+
+-- Recalculate the penalty when a synced player levels up their actual job
+m:addOverride('xi.player.onPlayerLevelUp', function(player)
+    super(player)
+
+    if player:hasStatusEffect(xi.effect.LEVEL_SYNC) then
+        applyPenalty(player)
+    end
+end)
+
+-- Apply penalty when level sync effect is gained
+m:addOverride('xi.effects.level_sync.onEffectGain', function(target, effect)
+    super(target, effect)
+
+    if target:getObjType() == xi.objType.PC then
+        applyPenalty(target)
+    end
+end)
+
+-- Remove penalty when level sync effect is lost
+m:addOverride('xi.effects.level_sync.onEffectLose', function(target, effect)
+    super(target, effect)
+
+    if target:getObjType() == xi.objType.PC then
+        removePenalty(target)
+    end
+end)
+
+return m


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Previous module was merged to the `base` branch, imports it into the proper `beta` branch
- Update to include the grace level gap in the exp penalty calculation once it kicks in.

## Steps to test these changes

- Load module, adjust thresholds for a locally testable amount
- Login multiple accounts and level sync while 11 levels above the sync target
- See the exp amount gained is reduced