### PR TITLE
[lua][module] Powerlevel nerf bug fix

### DIFF
--- a/modules/phoenix/lua/powerlevel_nerf.lua
+++ b/modules/phoenix/lua/powerlevel_nerf.lua
@@ -1,33 +1,16 @@
 -----------------------------------
 -- Phoenix Power Leveling Nerf Module
 --
--- Penalize players tanking mobs for parties they're not in.
--- Penalty stacks up to 5x (-20% EXP each), resets when mob roams at full HP.
+-- Dirty exp of monsters if they attack a player that is more than 5 levels above them more than 3 times.
 -----------------------------------
 require('modules/module_utils')
 
 local m = Module:new('powerlevel_nerf')
 
 -- Configuration
-local maxPenalty      = 5
-local penaltyPerStack = 20  -- 20% reduction per stack
-
--- Applies roam listener to mob to ensure exp penalty resets when mob roams at full HP
-local function applyRoamListener(mob)
-    if mob:getLocalVar('expReduction') > 0 then
-        return
-    end
-
-    mob:addListener('ROAM_TICK', 'POWERLEVEL_NERF_ROAM', function(mobEntity)
-        if mobEntity:getHPP() < 100 then
-            return
-        end
-
-        mobEntity:setLocalVar('expReduction', 0)
-        mobEntity:setMobMod(xi.mobMod.EXP_BONUS, 0)
-        mobEntity:removeListener('POWERLEVEL_NERF_ROAM')
-    end)
-end
+local levelGrace = 5  -- Only stamp players this many levels or more above the mob
+local swingGrace = 3  -- Attack rounds against a player before stamping begins
+local graceReset = 60 -- Seconds without being hit before the swing count resets
 
 m:addOverride('xi.player.onGameIn', function(player, firstLogin, zoning)
     super(player, firstLogin, zoning)
@@ -41,37 +24,28 @@ m:addOverride('xi.player.onGameIn', function(player, firstLogin, zoning)
             return
         end
 
-         -- Don't continue if the mob has no enmity table (not claimed)
-        local enmityList = attacker:getEnmityList()
-        if not enmityList or not next(enmityList) then
+        -- Within the level range of the mob's intended killers
+        if playerEntity:getMainLvl() < attacker:getMainLvl() + levelGrace then
             return
         end
 
-        -- Mob is claimed - check if player has claim
-        if playerEntity:hasClaim(attacker) then
+        local now    = GetSystemTime()
+        local swings = attacker:getLocalVar('plNerfSwings')
+
+        -- Stale count from an earlier engagement
+        if now - attacker:getLocalVar('plNerfLastHit') > graceReset then
+            swings = 0
+        end
+
+        swings = swings + 1
+        attacker:setLocalVar('plNerfSwings', swings)
+        attacker:setLocalVar('plNerfLastHit', now)
+
+        if swings < swingGrace then
             return
         end
 
-        if attacker:getMobMod(xi.mobMod.EXP_BONUS) <= -100 then
-            return
-        end
-
-        -- Mob is already at max penalty
-        local currentPenalty = attacker:getLocalVar('expReduction')
-        if currentPenalty >= maxPenalty then
-            return
-        end
-
-        -- Apply roam listener to reset penalty if mob deaggros
-        if currentPenalty == 0 then
-            applyRoamListener(attacker)
-        end
-
-        currentPenalty = currentPenalty + 1
-        attacker:setLocalVar('expReduction', currentPenalty)
-
-        local expReduction = math.floor(-currentPenalty * penaltyPerStack)
-        attacker:setMobMod(xi.mobMod.EXP_BONUS, expReduction)
+        attacker:updateEnmityFromDamage(playerEntity, 1)
     end)
 end)
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- My previous implementation was falsely triggering on white mobs attacking a solo player
- Reworks the logic to dirty the exp after 4 swings. Has no effect on players attacking mobs at their level, but power levelers at a higher level will now impact the exp gained as if they acted on the mob.

## Steps to test these changes

- Load module and load 3 accounts
- Level sync two of the characters to a low level and pull a mob
- Pull threat on the mob on the 3rd account at a high level
- See that the exp is impacted after 4 swings
