### PR TITLE
[lua] Remove Pallas from Claim Shield

### DIFF
--- a/modules/custom/lua/claim_shield.lua
+++ b/modules/custom/lua/claim_shield.lua
@@ -293,11 +293,6 @@ local shieldedEntities =
         'Bonnacon',
     },
 
-    ['Upper_Delkfutts_Tower'] =
-    {
-        'Pallas',
-    },
-
     ['Valkurm_Dunes'] =
     {
         'Valkurm_Emperor',


### PR DESCRIPTION
Pallas is a trade pop (qm2 in Upper Delkfutt's Tower) that spawns claimed to the trader via npcUtil.popFromQM. The claim shield strips that claim and lotteries it to anyone on the enmity list, letting bystanders win a pop the trader farmed for.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR removes Pallas from the claim shield module because he is supposed to pop claimed to the popper, not have a claim shield window.

## Steps to test these changes

Pop Pallas. See he pops claimed to the popper like he is supposed to.
