### PR TITLE
[cpp] Create merit patch file for era category caps and costs

### DIFF
--- a/modules/phoenix/patches/.gitattributes
+++ b/modules/phoenix/patches/.gitattributes
@@ -1,0 +1,2 @@
+# Keep patch files exactly as committed. Git may rewrite line endings, and a rewritten patch no longer matches the files it changes, so it fails to apply.
+*.patch -text

--- a/modules/phoenix/patches/README.md
+++ b/modules/phoenix/patches/README.md
@@ -1,0 +1,3 @@
+C++ patch files to be ran on the server side prior to build time for Phoenix or era specific adjustments.
+
+Allows us to override C++ files that are otherwise not able to be moduled temporarily until an upstream fix can be accomplished.

--- a/modules/phoenix/patches/merit_era_caps.patch
+++ b/modules/phoenix/patches/merit_era_caps.patch
@@ -1,0 +1,112 @@
+diff --git a/src/map/merit.cpp b/src/map/merit.cpp
+index a1602cdbaf..0a9aa17191 100644
+--- a/src/map/merit.cpp
++++ b/src/map/merit.cpp
+@@ -28,19 +28,16 @@
+ 
+ // clang-format off
+ static uint8 upgrade[10][45] = {
+-    { 1, 2, 3, 4, 5, 5, 5, 5, 5, 7, 7, 7, 9, 9, 9 },           // HP-MP
+-    { 3, 6, 9, 9, 9, 12, 12, 12, 12, 15, 15, 15, 15, 18, 18 }, // Attributes
+-    { 1, 2, 3, 3, 3, 3, 3, 3 },                                // Combat Skills
+-    { 1, 2, 3, 3, 3, 3, 3, 3 },                                // Defensive Skills
+-    { 1, 2, 3, 3, 3, 3, 3, 3 },                                // Magic Skills
+-    { 1, 2, 3, 4, 5 },                                         // Others
+-    { 1, 2, 3, 4, 5 },                                         // Job Group 1
+-    { 3, 4, 5, 5, 5 },                                         // Job Group 2
+-    { 20, 22, 24, 27, 30 },                                    // Weapon Skills
+-    { 1, 3, 5, 7, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39,
+-      42, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 48, 48, 48,
+-      48, 48, 48, 48, 48, 48, 48, 51, 51, 51, 51, 51, 51, 51,
+-      51, 51 } // Max merits
++    { 1, 2, 3, 4, 5, 5, 5, 5 }, // HP-MP
++    { 3, 6, 9, 9, 9 },          // Attributes
++    { 1, 2, 3, 3, 3, 3, 3, 3 }, // Combat Skills
++    { 1, 2, 3, 3 },             // Defensive Skills
++    { 1, 2, 3, 3, 3, 3, 3, 3 }, // Magic Skills
++    { 1, 2, 3, 4 },             // Others
++    { 1, 2, 3, 4, 5 },          // Job Group 1
++    { 3, 4, 5, 5, 5 },          // Job Group 2
++    { 99 },                     // Weapon Skills
++    { 99 }                      // Max merits
+ };
+ // clang-format on
+ 
+@@ -75,11 +72,11 @@ struct MeritCategoryInfo_t
+ 
+ // clang-format off
+ static const MeritCategoryInfo_t meritCatInfo[] = {
+-    { 3, 75, 0 },   // MCATEGORY_HP_MP       catNumber 00 (HP 15, MP 15, Max_merits 45)
+-    { 7, 105, 1 },  // MCATEGORY_ATTRIBUTES  catNumber 01
+-    { 19, 152, 2 }, // MCATEGORY_COMBAT      catNumber 02
+-    { 14, 112, 4 }, // MCATEGORY_MAGIC       catNumber 03
+-    { 5, 10, 5 },   // MCATEGORY_OTHERS      catNumber 04
++    { 3, 8, 0 },    // MCATEGORY_HP_MP       catNumber 00 (HP 15, MP 15, Max_merits 45)
++    { 7, 5, 1 },    // MCATEGORY_ATTRIBUTES  catNumber 01
++    { 19, 20, 2 },  // MCATEGORY_COMBAT      catNumber 02
++    { 14, 16, 4 },  // MCATEGORY_MAGIC       catNumber 03
++    { 5, 8, 5 },    // MCATEGORY_OTHERS      catNumber 04
+ 
+     { 5, 10, 6 }, // MCATEGORY_WAR_1       catNumber 05
+     { 5, 10, 6 }, // MCATEGORY_MNK_1       catNumber 06
+@@ -102,7 +99,7 @@ static const MeritCategoryInfo_t meritCatInfo[] = {
+     { 4, 10, 6 }, // MCATEGORY_DNC_1       catNumber 23
+     { 4, 10, 6 }, // MCATEGORY_SCH_1       catNumber 24
+ 
+-    { 14, 15, 8 }, // MCATEGORY_WS          catNumber 25
++    { 14, 0, 8 },  // MCATEGORY_WS          catNumber 25
+ 
+     { 5, 10, 6 }, // MCATEGORY_GEO_1       catNumber 26
+     { 5, 10, 6 }, // MCATEGORY_RUN_1       catNumber 27
+@@ -111,24 +108,24 @@ static const MeritCategoryInfo_t meritCatInfo[] = {
+     { 0, 0, 8 }, // MCATEGORY_UNK_1       catNumber 29
+     { 0, 0, 8 }, // MCATEGORY_UNK_2       catNumber 30
+ 
+-    { 4, 10, 7 },  // MCATEGORY_WAR_2       catNumber 31
+-    { 4, 10, 7 },  // MCATEGORY_MNK_2       catNumber 32
+-    { 6, 10, 7 },  // MCATEGORY_WHM_2       catNumber 33
+-    { 12, 10, 7 }, // MCATEGORY_BLM_2       catNumber 34
+-    { 12, 10, 7 }, // MCATEGORY_RDM_2       catNumber 35
+-    { 4, 10, 7 },  // MCATEGORY_THF_2       catNumber 36
+-    { 4, 10, 7 },  // MCATEGORY_PLD_2       catNumber 37
+-    { 4, 10, 7 },  // MCATEGORY_DRK_2       catNumber 38
+-    { 4, 10, 7 },  // MCATEGORY_BST_2       catNumber 39
+-    { 6, 10, 7 },  // MCATEGORY_BRD_2       catNumber 40
+-    { 4, 10, 7 },  // MCATEGORY_RNG_2       catNumber 41
+-    { 4, 10, 7 },  // MCATEGORY_SAM_2       catNumber 42
+-    { 12, 10, 7 }, // MCATEGORY_NIN_2       catNumber 43
+-    { 4, 10, 7 },  // MCATEGORY_DRG_2       catNumber 44
+-    { 6, 10, 7 },  // MCATEGORY_SMN_2       catNumber 45
+-    { 4, 10, 7 },  // MCATEGORY_BLU_2       catNumber 46
+-    { 4, 10, 7 },  // MCATEGORY_COR_2       catNumber 47
+-    { 4, 10, 7 },  // MCATEGORY_PUP_2       catNumber 48
++    { 4, 6, 7 },   // MCATEGORY_WAR_2       catNumber 31
++    { 4, 6, 7 },   // MCATEGORY_MNK_2       catNumber 32
++    { 6, 6, 7 },   // MCATEGORY_WHM_2       catNumber 33
++    { 12, 6, 7 },  // MCATEGORY_BLM_2       catNumber 34
++    { 12, 6, 7 },  // MCATEGORY_RDM_2       catNumber 35
++    { 4, 6, 7 },   // MCATEGORY_THF_2       catNumber 36
++    { 4, 6, 7 },   // MCATEGORY_PLD_2       catNumber 37
++    { 4, 6, 7 },   // MCATEGORY_DRK_2       catNumber 38
++    { 4, 6, 7 },   // MCATEGORY_BST_2       catNumber 39
++    { 6, 6, 7 },   // MCATEGORY_BRD_2       catNumber 40
++    { 4, 6, 7 },   // MCATEGORY_RNG_2       catNumber 41
++    { 4, 6, 7 },   // MCATEGORY_SAM_2       catNumber 42
++    { 12, 6, 7 },  // MCATEGORY_NIN_2       catNumber 43
++    { 4, 6, 7 },   // MCATEGORY_DRG_2       catNumber 44
++    { 6, 6, 7 },   // MCATEGORY_SMN_2       catNumber 45
++    { 4, 6, 7 },   // MCATEGORY_BLU_2       catNumber 46
++    { 4, 6, 7 },   // MCATEGORY_COR_2       catNumber 47
++    { 4, 6, 7 },   // MCATEGORY_PUP_2       catNumber 48
+     { 4, 10, 7 },  // MCATEGORY_DNC_2       catNumber 49
+     { 6, 10, 7 },  // MCATEGORY_SHC_2       catNumber 50
+ 
+@@ -495,6 +492,8 @@ void LoadMeritsList()
+     }
+ 
+     groupOffset[catIndex] = index - catMeritIndex; // add the last offset manually since loop finishes before hand.
++
++    ShowInfo("Phoenix era merit caps patch active");
+ }
+ 
+ }; // namespace meritNameSpace


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Creates a new patch directory to store C++ patch files for code that is otherwise not able to be moduled over
- New merit.cpp patch file to override merit upgrade costs and category caps.

## Steps to test these changes

- Run `git apply modules/phoenix/patches/merit_era_caps.patch`
- See that merit.cpp has been adjusted locally
- Build the server
- Try to upgrade a merit category past the listed cap, see you are blocked from putting more than 6 upgrades in group 2 merits