### PR TITLE
[sql] Tales' Beginning Module

### DIFF
--- a/modules/phoenix/sql/pxi_npc_lists.sql
+++ b/modules/phoenix/sql/pxi_npc_lists.sql
@@ -6,3 +6,13 @@
 UPDATE `npc_list` SET `content_tag` = NULL WHERE `npcid` = 17408033 AND `name` = 'qm0'; -- Dragons Aery
 UPDATE `npc_list` SET `content_tag` = NULL WHERE `npcid` = 17301543 AND `name` = 'qm0'; -- Valley of Sorrows
 UPDATE `npc_list` SET `content_tag` = NULL WHERE `npcid` = 17297459 AND `name` = 'qm2'; -- Behemoths Dominion
+
+-- Retags the expansion-specific "Tales' Beginning" NPCs from TVR to the
+-- expansion whose storyline they actually start, so that players who skip
+-- cutscenes can use them. This is because we have decided not to remove
+-- the cutscene skip options from the game, and we want to avoid players
+-- being unable to use these NPCs if they skip the cutscenes.
+UPDATE `npc_list` SET `content_tag` = 'COP'  WHERE `npcid` = 17531245 AND `name` = 'Tales_Beginning'; -- Lower Delkfutt's Tower (Zone 184), Chains of Promathia
+UPDATE `npc_list` SET `content_tag` = 'ACP'  WHERE `npcid` = 17781072 AND `name` = 'Tales_Beginning'; -- Lower Jeuno (Zone 245), A Crystalline Prophecy
+UPDATE `npc_list` SET `content_tag` = 'ROTZ' WHERE `npcid` = 17809554 AND `name` = 'Tales_Beginning'; -- Norg (Zone 252), Rise of the Zilart
+UPDATE `npc_list` SET `content_tag` = 'ASA'  WHERE `npcid` = 17756512 AND `name` = 'Tales_Beginning'; -- Windurst Walls (Zone 239), A Shantotto Ascension


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR creates an SQL module to enable Tales' Beginning to appear for Rise of the Zilart Missions, Chains of Promathia Missions, A Crystalline Prophecy Missions, and A Shantotto Ascension Missions. This lets us keep the QOL functionality for cutscene skipping and returning later without needing to change how the cutscenes are delivered on our end.

Note: Only the COP one works upstream right now, so the others will need to be coded.

## Steps to test these changes

Load the module. Change your server settings. Depending on what you enable, See that the Tales' Beginning NPCs load in the corresponding zones:

- ROTZ - Norg (H-9)
- COP - Lower Delkfutt's Tower, First Floor (H-10)
- ACP - Lower Jeuno (G-9)
- ASA - Windurst Walls (C-6)