### PR TITLE
[lua] Various Dynamis Fixes

### DIFF
--- a/modules/phoenix/dynamis/lua/dynamis_overrides.lua
+++ b/modules/phoenix/dynamis/lua/dynamis_overrides.lua
@@ -821,6 +821,9 @@ local mobNames =
 local function registerDynamisZoneOverrides(zoneID, zoneName, zoneNumber)
     m:addOverride(string.format('xi.zones.%s.Zone.onInitialize', zoneName),
     function(zone)
+        -- Clean left over vars on restarts
+        xi.dynamis.clearOnInit(zone)
+
         if zoneID == xi.zone.DYNAMIS_TAVNAZIA then
             xi.dynamis.onZoneInitTav(zone)
         end
@@ -1155,9 +1158,14 @@ local mobOverrideHandlers =
             xi.dynamis.onMobDisengage(mob)
         end,
 
-        -- Summoner-type masters (avatar pet) 2hr and resummon; no-op for BST/DRG masters
+        -- Masters own their 2hr by main job: SMN = Astral Flow (+ avatar resummon), BST = Familiar/Charm
         onMobFight = function(mob, target)
-            xi.dynamis.summonerOnFight(mob, target)
+            local masterJob = mob:getMainJob()
+            if masterJob == xi.job.SMN then
+                xi.dynamis.summonerOnFight(mob, target)
+            elseif masterJob == xi.job.BST then
+                xi.dynamis.beastmasterOnFight(mob, target)
+            end
         end,
 
         onMobDeath = function(mob, player, optParams)
@@ -1276,7 +1284,7 @@ local function registerMobOverrides(zoneName, mobName, overrideMobType, modelSiz
             elseif overrideMobType == mobType.MASTER then
                 handler = function(mob)
                     xi.dynamis.onMobSpawn(mob, overrideMobType, modelSize)
-                    xi.dynamis.summonerOnSpawn(mob) -- No-op unless the master's pet is an avatar
+                    xi.dynamis.masterOnSpawn(mob)
                 end
             elseif overrideMobType == mobType.AVATAR then
                 handler = function(mob)

--- a/scripts/commands/adddynatime.lua
+++ b/scripts/commands/adddynatime.lua
@@ -48,7 +48,7 @@ commandObj.onTrigger = function(player, minutes, target)
     local oldDuration = effect:getDuration()
     effect:setDuration((oldDuration + (minutes * 60)) * 1000)
     targ:setLocalVar('dynamis_lasttimeupdate', effect:getTimeRemaining() / 1000)
-    targ:messageSpecial(ID.text.DYNAMIS_TIME_EXTEND, minutes)
+    targ:messageSpecial(ID.text.DYNAMIS_TIME_EXTEND, minutes, 1)
 end
 
 return commandObj

--- a/scripts/globals/dynamis/dynamis_mobinfo.lua
+++ b/scripts/globals/dynamis/dynamis_mobinfo.lua
@@ -633,20 +633,13 @@ xi.dynamis.onBossDeath = function(mob, player, optParams)
 end
 
 -- ---------------------
--- Summoner masters and their avatar pets
+-- Summoner and Beastmaster 2 hour functions
 -- ---------------------
 -- Dynamis summon mechanics:
--- Call a random avatar shortly after spawning
--- Summonm stays out and fights. Once the master goes below a certain % it uses astral flow
-local summonerCallPetParams =
-{
-    callPetJob   = xi.job.SMN,
-    inactiveTime = 3000, -- Casting animation time
-    superLink    = true,
-    dieWithOwner = true,
-    maxSpawns    = 1,
-}
-
+-- SMN: Call a random avatar shortly after spawning
+--      Summon stays out and fights. Once the master goes below a certain % it uses astral flow
+-- BST: Call its pet shortly after spawning (same summoning animation as SMN masters)
+--      The pet is never resummoned. 2hr is Familiar if the pet is alive, Charm if it is dead
 local possibleAvatars =
 {
     xi.pets.summon.type.CARBUNCLE,
@@ -658,8 +651,8 @@ local possibleAvatars =
     xi.pets.summon.type.RAMUH,
 }
 
--- A master counts as a summoner when the pet slotted after it is an avatar
-local function getAvatarPet(master)
+-- pet is master + 1
+local function getMasterPet(master)
     local pet = GetMobByID(master:getID() + 1)
     if pet then
         return pet
@@ -668,51 +661,72 @@ local function getAvatarPet(master)
     return nil
 end
 
--- Retry the summon until it goes off (callPets fails while slept/stunned)
--- Once the avatar is out, death is permanent - thank you BO
-local function trySummonAvatar(mob)
+-- Retry the summon until it goes off (note: callPets fails while slept/stunned)
+-- Once the pet is out, death is permanent - thank you BO
+local function trySummonPet(mob)
     if not mob:isSpawned() or mob:isDead() then
         return
     end
 
-    local pet = getAvatarPet(mob)
+    local pet = getMasterPet(mob)
     if not pet or pet:isAlive() then
         return
     end
 
-    if not xi.mob.callPets(mob, pet:getID(), summonerCallPetParams) then
+    local callPetParams =
+    {
+        callPetJob   = xi.job.SMN, -- BST masters use the SMN summoning animation too
+        inactiveTime = 3000, -- Casting animation time
+        superLink    = true,
+        dieWithOwner = mob:getMainJob() == xi.job.SMN, -- BST pets stay alive if master dies
+        maxSpawns    = 1,
+    }
+
+    if not xi.mob.callPets(mob, pet:getID(), callPetParams) then
         mob:timer(3000, function(mobArg)
-            trySummonAvatar(mobArg)
+            trySummonPet(mobArg)
         end)
     end
 end
 
-xi.dynamis.summonerOnSpawn = function(mob)
-    local pet = getAvatarPet(mob)
+-- Shared spawn logic for SMN and BST masters
+xi.dynamis.masterOnSpawn = function(mob)
+    local masterJob = mob:getMainJob()
+    if masterJob ~= xi.job.SMN and masterJob ~= xi.job.BST then
+        return
+    end
+
+    local pet = getMasterPet(mob)
     if not pet then
         return
     end
 
-    -- Remove the spell list because when it casts a spell the entire summons dont work
-    mob:setSpellList(0)
+    if masterJob == xi.job.SMN then
+        -- Remove the spell list because when it casts a spell the entire summons dont work
+        mob:setSpellList(0)
 
-    -- Our avatar is at mob ID + 1; the astral_flow mobskill defaults to +2
-    mob:setMobMod(xi.mobMod.ASTRAL_PET_OFFSET, 1)
+        -- avatar is +1
+        mob:setMobMod(xi.mobMod.ASTRAL_PET_OFFSET, 1)
+    else
+        -- Removes call beast from the skill list
+        mob:setMobMod(xi.mobMod.SPECIAL_SKILL, 0)
+    end
 
-    -- Randomize the HP% that triggers Astral Flow for this pop
-    mob:setLocalVar('astralFlowHPP', math.randomInt(25, 75))
+    -- Randomize the HP% that triggers the 2hr
+    mob:setLocalVar('twoHourHPP', math.randomInt(25, 75))
 
-    -- Mute the job_special mixin's auto-2hr; our logic owns Astral Flow
+    -- Stop the job mixin
     mob:setLocalVar('[jobSpecial]chance', 0)
 
-    -- Summon the avatar shortly after spawning
+    -- Call the pet shortly after spawning
+    -- Might need tweaking
     mob:timer(2000, function(mobArg)
-        trySummonAvatar(mobArg)
+        trySummonPet(mobArg)
     end)
 end
 
 xi.dynamis.summonerOnFight = function(mob, target)
-    local pet = getAvatarPet(mob)
+    local pet = getMasterPet(mob)
     if not pet then
         return
     end
@@ -723,10 +737,10 @@ xi.dynamis.summonerOnFight = function(mob, target)
 
     -- Do the 2hr and set the var for astral flow
     if
-        mob:getLocalVar('astralFlowUsed') == 0 and
-        mob:getHPP() < mob:getLocalVar('astralFlowHPP')
+        mob:getLocalVar('twoHourUsed') == 0 and
+        mob:getHPP() < mob:getLocalVar('twoHourHPP')
     then
-        mob:setLocalVar('astralFlowUsed', 1)
+        mob:setLocalVar('twoHourUsed', 1)
 
         if pet:isAlive() then
             -- Engage the avatar and tell it to fire its flow ability
@@ -749,6 +763,36 @@ xi.dynamis.summonerOnFight = function(mob, target)
 
         mob:useMobAbility(xi.mobSkill.ASTRAL_FLOW_1)
         return
+    end
+end
+
+xi.dynamis.beastmasterOnFight = function(mob, target)
+    local pet = getMasterPet(mob)
+    if not pet then
+        return
+    end
+
+    if xi.combat.behavior.isEntityBusy(mob) then
+        return
+    end
+
+    -- Can only use the 2hrs once
+    -- Familiar if the pet is still alive
+    -- Charm if it is dead
+    if
+        mob:getLocalVar('twoHourUsed') == 0 and
+        mob:getLocalVar('twoHourHPP') > 0 and
+        mob:getHPP() < mob:getLocalVar('twoHourHPP')
+    then
+        mob:setLocalVar('twoHourUsed', 1)
+
+        if pet:isAlive() then
+            mob:useMobAbility(xi.mobSkill.FAMILIAR_1)
+            debugPrint('Master ' .. mob:getID() .. ' 2hr Familiar with pet ' .. pet:getID() .. ' alive')
+        else
+            mob:useMobAbility(xi.mobSkill.CHARM)
+            debugPrint('Master ' .. mob:getID() .. ' 2hr Charm, pet dead')
+        end
     end
 end
 

--- a/scripts/globals/dynamis/dynamis_system.lua
+++ b/scripts/globals/dynamis/dynamis_system.lua
@@ -322,7 +322,7 @@ xi.dynamis.addMinutesToDynamis = function(zone, minutes)
 
     -- Update Hourglasses for Players
     for _, player in pairs(playersInZone) do
-        player:messageSpecial(zones[zoneId].text.DYNAMIS_TIME_EXTEND, minutes)
+        player:messageSpecial(zones[zoneId].text.DYNAMIS_TIME_EXTEND, minutes, 1)
         xi.dynamis.updatePlayerHourglass(player)
     end
 
@@ -387,11 +387,6 @@ xi.dynamis.cleanupDynamis = function(zone)
     xi.dynamis.debugPrint('----------Cleaning up Dynamis zone: ' .. tostring(zone:getID()))
     xi.dynamis.debugPrint('Cleaning up Dynamis zone: ' .. tostring(zoneId))
 
-    if parentZone == nil then
-        xi.dynamis.debugPrint('Parent Zone is nil | xi.dynamis.cleanupDynamis')
-        return
-    end
-
     -- Reset server vars
     SetServerVariable(string.format('[DYNA]#OfRegisteredPlayers_%s', zoneId), 0)
     SetServerVariable(string.format('[DYNA]StartTime_%s', zoneId), 0)
@@ -401,7 +396,14 @@ xi.dynamis.cleanupDynamis = function(zone)
 
     -- Reset local vars
     zone:resetLocalVars()
-    parentZone:setLocalVar(string.format('[DYNA]CleanupScript_%s', zoneId), 1)
+
+    -- The parent zone can be nil when this runs from onInit
+    -- Everything above/below is zone-side, so only the parent zone is skipped
+    if parentZone then
+        parentZone:setLocalVar(string.format('[DYNA]CleanupScript_%s', zoneId), 1)
+    else
+        xi.dynamis.debugPrint('Parent Zone is nil | xi.dynamis.cleanupDynamis')
+    end
 
     -- Reset associated player vars
     local instanceId = GetServerVariable(string.format('[DYNA]InstanceID_%s', zoneId))
@@ -412,6 +414,23 @@ xi.dynamis.cleanupDynamis = function(zone)
 
     xi.dynamis.ejectAllPlayers(zone) -- Remove Players (This is precautionary but not necessary.)
     xi.dynamis.despawnAll(zone) -- Despawns all mobs / npcs in zone
+end
+
+-- Tick cleanup does not run when the server restarts
+-- Clear all the vars that dont get cleaned up
+xi.dynamis.clearOnInit = function(zone)
+    local zoneId = zone:getID()
+
+    if
+        GetServerVariable(string.format('[DYNA]StartTime_%s', zoneId)) == 0 and
+        GetServerVariable(string.format('[DYNA]ExpirationTime_%s', zoneId)) == 0
+    then
+        return
+    end
+
+    xi.dynamis.debugPrint('Found stale Dynamis run for zone ' .. zoneId .. ' after a restart, running full cleanup')
+
+    xi.dynamis.cleanupDynamis(zone)
 end
 
 xi.dynamis.despawnAll = function(zone)
@@ -425,6 +444,9 @@ xi.dynamis.despawnAll = function(zone)
 
     for _, npcEntity in pairs(npcsInZone) do
         npcEntity:setStatus(xi.status.DISAPPEAR)
+
+        -- Clear NPC local vars since they dont reset on cleanup
+        npcEntity:resetLocalVars()
         xi.dynamis.debugPrint('despawnAll DISAPPEAR NPC ID: ' .. tostring(npcEntity:getID()))
     end
 end
@@ -440,6 +462,29 @@ xi.dynamis.dynamisTimeWarning = function(zone, zoneExpiration)
         else
             player:messageSpecial(ID.text.DYNAMIS_TIME_UPDATE_2, timeRemaining, 1) -- Send [3/10] minutes warning.
         end
+    end
+end
+
+-- Applies weakness when a player re-enters dynamis
+local applyReentryWeakness = function(player, zoneId)
+    -- Ignore GMs
+    if xi.dynamis.isGM(player) then
+        return
+    end
+
+    local startTime = GetServerVariable(string.format('[DYNA]StartTime_%s', zoneId))
+    if startTime == 0 then
+        return
+    end
+
+    local playerEntered = string.format('[DYNA]EnteredRun_%s', zoneId)
+
+    if player:getCharVar(playerEntered) == startTime then
+        xi.dynamis.debugPrint('Player re-entered an active run, applying weakness')
+        player:addStatusEffect(xi.effect.WEAKNESS, { power = 1, duration = xi.dynamis.settings.REENTRY_WEAKNESS, origin = player })
+    else
+        -- On first zone in set the charvar and set expiry
+        player:setCharVar(playerEntered, startTime, startTime + 86400)
     end
 end
 
@@ -477,6 +522,9 @@ xi.dynamis.zoneOnZoneInEra = function(player, prevZone)
 
     -- Check for dreamland SJ restriction and apply if necessary
     xi.dynamis.applyEntryRestrictions(player, zoneId)
+
+    -- Re-entry/reconnect weakness
+    applyReentryWeakness(player, zoneId)
     return -1
 end
 

--- a/scripts/globals/dynamis/ejection.lua
+++ b/scripts/globals/dynamis/ejection.lua
@@ -3,6 +3,7 @@
 --   Dynamis Eject Functions
 -----------------------------------
 local ejectWarningTimer      = 2000
+local ejectDeadDelay   = 10000
 local ejectWarningVar        = 'Received_Eject_Warning'
 local ejectCutsceneQueuedVar = '[DYNA]EjectCutsceneQueued'
 
@@ -32,6 +33,22 @@ xi.dynamis.performEjectActions = function(player, zoneId, cutsceneDelayMs)
         if playerArg:getCurrentRegion() == xi.region.DYNAMIS then
             playerArg:startCutscene(100)
         end
+    end)
+
+    -- The eject cutscene cannot run for dead players so we need to ejec them afterwards
+    -- Add 10 seconds to the 30 second grace timer
+    player:timer(cutsceneDelayMs + ejectDeadDelay, function(playerArg)
+        if playerArg:getZoneID() ~= zoneId then
+            return
+        end
+
+        local dynaInfo = xi.dynamis.dynaInfoEra[zoneId]
+        if dynaInfo and dynaInfo.ejectPos then
+            playerArg:setPos(unpack(dynaInfo.ejectPos))
+        end
+
+        -- Reset after timer
+        xi.dynamis.resetEjectState(playerArg)
     end)
 end
 

--- a/scripts/globals/dynamis/entry_era.lua
+++ b/scripts/globals/dynamis/entry_era.lua
@@ -23,23 +23,26 @@ xi.dynamis.checkEntryRequirements = function(player, entryZoneID)
 
     xi.dynamis.debugPrint('Checking player charvar ' .. entryInfo.enteredVar .. ' for previous Dynamis entry.')
 
-    -- 1. GMs and players who have previously entered this zone bypass all requirements
-    --    This allows GMs to test content and returning players to enter freely
-    if
-        xi.dynamis.isGM(player) or
-        player:getCharVar(entryInfo.enteredVar) ~= 0
-    then
-        xi.dynamis.debugPrint('Player is GM or has already entered this Dynamis before, skipping requirements.')
+    -- 1. GMs bypass all requirements so they can test content
+    if xi.dynamis.isGM(player) then
+        xi.dynamis.debugPrint('Player is GM, skipping requirements.')
         return true
     end
 
     -- 2. Player must be at least level 65 to enter Dynamis
+    -- Checked on EVERY entry - players can leave, change jobs and try to come back
     if player:getMainLvl() < xi.dynamis.settings.MIN_LEVEL then
         player:printToPlayer('Players who have not reached 65 are prohibited from entering Dynamis.', xi.msg.channel.NS_SAY)
         return false
     end
 
-    -- 3. Dreamlands Dynamis (zones 7+) requires completion of "Darkness Named" CoP mission
+    -- 3. Players who have previously skip the other checks
+    if player:getCharVar(entryInfo.enteredVar) ~= 0 then
+        xi.dynamis.debugPrint('Player has already entered this Dynamis before, skipping one-time requirements.')
+        return true
+    end
+
+    -- 4. Dreamlands Dynamis (zones 7+) requires completion of "Darkness Named" CoP mission
     if
         entryInfo.csBit >= 7 and
         not player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.DARKNESS_NAMED)
@@ -49,7 +52,7 @@ xi.dynamis.checkEntryRequirements = function(player, entryZoneID)
         return false
     end
 
-    -- 4. Player must possess all zone-specific key items (e.g., past expansion items, progress flags)
+    -- 5. Player must possess all zone-specific key items (e.g., past expansion items, progress flags)
     for _, keyItemID in ipairs(entryInfo.reqs) do
         if not player:hasKeyItem(keyItemID) then
             xi.dynamis.debugPrint('Missing required key item to enter Dynamis: ' .. keyItemID)

--- a/scripts/globals/dynamis/npc_handlers.lua
+++ b/scripts/globals/dynamis/npc_handlers.lua
@@ -119,7 +119,6 @@ xi.dynamis.entryNpcOnTrade = function(player, npc, trade)
 
         -- 1. GM bypass - allow direct entry and registration
         if xi.dynamis.isGM(player) then
-            xi.dynamis.registerPlayer(player)
             player:startEvent(entryInfo.csDyna, entryInfo.csBit, playerEntered == 1 and 0 or 1, xi.dynamis.settings.RESERVATION_TIMEOUT, xi.dynamis.settings.REENTRY_DAYS, entryInfo.maxCapacity, xi.ki.VIAL_OF_SHROUDED_SAND, dynamisTimelessHourglass, dynamisPerpetual)
             return
         end
@@ -158,8 +157,7 @@ xi.dynamis.entryNpcOnTrade = function(player, npc, trade)
                 return
             end
 
-            -- Register player and allow entry
-            xi.dynamis.registerPlayer(player)
+            -- Registration (and its 72h lockout) happens in entryNpcOnEventFinishEra, only after the player confirms entry with !Ready (the first option)
             player:startEvent(entryInfo.csDyna, entryInfo.csBit, playerEntered == 1 and 0 or 1, xi.dynamis.settings.RESERVATION_TIMEOUT, xi.dynamis.settings.REENTRY_DAYS, entryInfo.maxCapacity, xi.ki.VIAL_OF_SHROUDED_SAND, dynamisTimelessHourglass, dynamisPerpetual)
             return
         end
@@ -364,6 +362,23 @@ xi.dynamis.entryNpcOnEventFinishEra = function(player, csid, option)
         if option ~= 0 then
             return
         end
+
+        -- Register the player now that they have confirmed entry.
+        -- Capacity was not reserved at trade time, so re-check it here
+        local dynaZoneId   = entryInfo.dynaZone
+        local instanceId   = GetServerVariable(string.format('[DYNA]InstanceID_%s', dynaZoneId))
+        local dynaCapacity = GetServerVariable(string.format('[DYNA]#OfRegisteredPlayers_%s', dynaZoneId))
+
+        if
+            not xi.dynamis.isGM(player) and
+            not xi.dynamis.isParticipant(instanceId, player:getID()) and
+            dynaCapacity >= entryInfo.maxCapacity
+        then
+            player:printToPlayer('The Dynamis instance has reached its maximum capacity of ' .. entryInfo.maxCapacity .. ' registrants.', 29)
+            return
+        end
+
+        xi.dynamis.registerPlayer(player)
 
         player:setCharVar(entryInfo.enteredVar, 1) -- Mark the player as having entered at least once
         player:setPos(unpack(entryInfo.enterPos))  -- Teleport to entry position

--- a/scripts/globals/dynamis/settings_era.lua
+++ b/scripts/globals/dynamis/settings_era.lua
@@ -12,6 +12,7 @@ xi.dynamis.settings =
     REENTRY_DAYS            = 3,
     DEFAULT_TIME_LIMIT      = 3600, -- 60 minutes default
     TAVNAZIA_TIME_LIMIT     = 900, -- 15 minutes for Tavnazia
+    REENTRY_WEAKNESS        = 600, -- weakness duration when re-entering/reconnecting to an active run
 }
 
 -- Messages for hourglass trade states


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Fixes beastmaster animations and two hours. The pet should correctly use familar when pet is alive and charm when the pet is dead. Also combined both summoner and bst logic together
- Fixes color of time extension text
- When re-entering dynamis you will now get a 10 minute weakness timer
- Fixes an issue where the player would click an OOE option for the perpetual hourglass and get locked out for 72 hours
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
**Beastmaster**
`!dynastart dynamis sandoria 1`
Aggro the statue in front of the AH by the first tent (forgot ID #)
see the beastmasters comes out -> wait -> spawn anim the pet
!hp 1 the first hawker
See it use familar
Kill both pets
!hp 1 the 100% hawker
see it charm you

**Weakness Timer**
Start a dynamis with command or the regular way
enter
leave...
enter again...see weakness

**OOE stuff**
Trade timless hourlgass
Trade perpetual and click on an OOR message and dont get locked out
<!-- Clear and detailed steps to test your changes here -->
