### PR TITLE
[Phoenix] Implement block for lockstyling gear you cannot wear

### DIFF
--- a/modules/phoenix/cpp/lockstyle_job_block.cpp
+++ b/modules/phoenix/cpp/lockstyle_job_block.cpp
@@ -1,0 +1,74 @@
+/************************************************************************
+ * Lockstyle Job Block
+ *
+ * Disallows players from lockstyling gear they cannot currently equip.
+ ************************************************************************/
+#include "map/entities/char_entity.h"
+#include "map/items/item_equipment.h"
+#include "map/packets/basic.h"
+#include "map/packets/c2s/0x053_lockstyle.h"
+#include "map/packets/s2c/0x11c_lockstyle_error.h"
+#include "map/utils/itemutils.h"
+#include "map/utils/moduleutils.h"
+
+#include <vector>
+
+class LockstyleJobBlock : public CPPModule
+{
+    void OnInit() override
+    {
+    }
+
+    auto OnIncomingPacket(MapSession* PSession, CCharEntity* PChar, CBasicPacket& data) -> bool override
+    {
+        // Return if the packet isn't lockstyle
+        if (data.getType() != static_cast<uint16>(GP_CLI_COMMAND_LOCKSTYLE::packetId))
+        {
+            return false;
+        }
+
+        auto* packet = data.as<GP_CLI_COMMAND_LOCKSTYLE>();
+        if (static_cast<GP_CLI_COMMAND_LOCKSTYLE_MODE>(packet->Mode) != GP_CLI_COMMAND_LOCKSTYLE_MODE::Set)
+        {
+            return false;
+        }
+
+        const uint8 mainJob    = static_cast<uint8>(PChar->GetMJob());
+        const uint8 equipLevel = PChar->GetMLevel();
+
+        // Iterate over player's intended equipment to be lockstyled and check if they are valid
+        std::vector<uint16_t> blockedItemIds;
+        for (uint8 i = 0; i < packet->Count; ++i)
+        {
+            auto& item = packet->Items[i];
+
+            if (item.ItemNo == 0 || item.EquipKind > SLOT_FEET)
+            {
+                continue;
+            }
+
+            const auto* PItem = xi::items::lookup<CItemEquipment>(item.ItemNo);
+            if (!PItem)
+            {
+                continue;
+            }
+
+            // Check if the item is equippable by the player's main job, and level
+            if (!(PItem->getJobs() & (1 << (mainJob - 1))) || PItem->getReqLvl() > equipLevel)
+            {
+                blockedItemIds.push_back(item.ItemNo);
+                item.ItemNo = 0;
+            }
+        }
+
+        if (!blockedItemIds.empty())
+        {
+            PChar->pushPacket<GP_SERV_COMMAND_LOCKSTYLE_ERROR>(blockedItemIds);
+        }
+
+        // Let the base handler process the sanitized set
+        return false;
+    }
+};
+
+REGISTER_CPP_MODULE(LockstyleJobBlock);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Implements a module to block the ability to lock style gear you cannot currently equip

## Steps to test these changes

- Load module
- Make a lock style set with gear your current job cannot equip
- Try lockstyling and see the gear is rejected from the lockstyle
On 75 WAR
<img width="710" height="65" alt="image" src="https://github.com/user-attachments/assets/baf0d7f4-9e33-439c-8673-23b3c10a6c49" />