### PR TITLE
[lua] Kirin teleport failure chance

### DIFF
--- a/modules/phoenix/lua/zones/The_Shrine_of_RuAvitau/Zone.lua
+++ b/modules/phoenix/lua/zones/The_Shrine_of_RuAvitau/Zone.lua
@@ -1,0 +1,18 @@
+-----------------------------------
+-- Adds the ability for the Kirin teleport to occasionally misfire and send you to the wrong location
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('kirin_teleporter')
+
+m:addOverride('xi.zones.The_Shrine_of_RuAvitau.Zone.onTriggerAreaEnter', function(player, triggerArea)
+    local areaId = triggerArea:getTriggerAreaID()
+
+    if areaId == 4 and math.randomInt(1, 100) <= 25 then
+        player:startOptionalCutscene(10, { cs_option = 0, canSkip = true })
+
+        return
+    end
+
+    super(player, triggerArea)
+end)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds a 25% chance when taking the teleport to Kirin's area for it to misfire and send you to the opposite room from Kirin.

## Steps to test these changes

- As it describes