### PR TITLE
[lua] ToAU mission progression blocker module

### DIFF
--- a/modules/phoenix/lua/missions/toau_mission_block.lua
+++ b/modules/phoenix/lua/missions/toau_mission_block.lua
@@ -1,0 +1,18 @@
+-----------------------------------
+-- Module: ToAU Mission Progression Block
+-- Currently blocking progressing past ToAU 18 Passing Glory. To be updated per Phoenix patch release.
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('toau_mission_block')
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/missions/toau/19_Sweets_for_the_Soul', function(mission)
+        local whitegate = mission.sections[1][xi.zone.AHT_URHGAN_WHITEGATE]
+
+        whitegate.onTriggerAreaEnter[5] = nil
+        whitegate.onEventFinish[3092]   = nil
+    end)
+end)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Phoenix will be staggering mission releases to match their release cadence with retail. This module adds a block from players being able to progress into ToAU 19 "Sweets for the Soul".
