### PR TITLE
Remove EXP and gil rewards from map quests

### DIFF
--- a/modules/phoenix/lua/Quests/A_Foremans_Best_Friend.lua
+++ b/modules/phoenix/lua/Quests/A_Foremans_Best_Friend.lua
@@ -1,0 +1,23 @@
+-----------------------------------
+-- Module to remove the exp compensation given by 'A Foreman's Best Friend' when the
+-- player already holds the map key item.
+-- Exp was added in 2013 so it is removed here.
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_a_foremans_best_friend', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/bastok/A_Foremans_Best_Friend', function(quest)
+        quest.sections[2][xi.zone.PORT_BASTOK].onEventFinish[112] = function(player, csid, option, npc)
+            if quest:complete(player) then
+                player:tradeComplete()
+                if not player:hasKeyItem(xi.ki.MAP_OF_THE_GUSGEN_MINES) then
+                    npcUtil.giveKeyItem(player, xi.ki.MAP_OF_THE_GUSGEN_MINES)
+                end
+            end
+        end
+    end)
+end)

--- a/modules/phoenix/lua/Quests/A_Smudge_on_Ones_Record.lua
+++ b/modules/phoenix/lua/Quests/A_Smudge_on_Ones_Record.lua
@@ -1,0 +1,19 @@
+-----------------------------------
+-- Module to remove exp and fame from 'A Smudge on One's Record' quest reward, and
+-- correct the gil reward to 3,000.
+-- Gil and exp were added to the quest reward in 2013 so exp is removed and gil corrected here.
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_a_smudge_on_ones_record', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/windurst/A_Smudge_on_Ones_Record', function(quest)
+        quest.reward = {
+            keyItem = xi.ki.MAP_OF_FEIYIN,
+            gil     = 3000,
+        }
+    end)
+end)

--- a/modules/phoenix/lua/Quests/Exit_the_Gambler.lua
+++ b/modules/phoenix/lua/Quests/Exit_the_Gambler.lua
@@ -1,0 +1,18 @@
+-----------------------------------
+-- Module to remove exp, gil, and fame from 'Exit the Gambler' quest reward.
+-- Gil and exp were added to the quest reward in 2013 so they are removed here.
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_exit_the_gambler', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/sandoria/Exit_the_Gambler', function(quest)
+        quest.reward = {
+            keyItem = xi.ki.MAP_OF_KING_RANPERRES_TOMB,
+            title   = xi.title.DAYBREAK_GAMBLER,
+        }
+    end)
+end)

--- a/modules/phoenix/lua/Quests/Glyph_Hanger.lua
+++ b/modules/phoenix/lua/Quests/Glyph_Hanger.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- Module to remove exp and fame from 'Glyph Hanger' quest reward.
+-- Exp was added to the quest reward in 2013 so it is removed here.
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_glyph_hanger', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/windurst/Glyph_Hanger', function(quest)
+        quest.reward = {
+            keyItem = xi.ki.MAP_OF_THE_HORUTOTO_RUINS,
+        }
+    end)
+end)

--- a/modules/phoenix/lua/Quests/Go_Go_Gobmuffin.lua
+++ b/modules/phoenix/lua/Quests/Go_Go_Gobmuffin.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- Module to remove exp and gil from 'Go Go Gobmuffin' quest reward.
+-- Gil and exp were added to the quest reward in 2013 so they are removed here.
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_go_go_gobmuffin', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/otherAreas/Go_Go_Gobmuffin', function(quest)
+        quest.reward = {
+            keyItem = xi.ki.MAP_OF_CAPE_RIVERNE,
+        }
+    end)
+end)

--- a/modules/phoenix/lua/Quests/Lost_in_Translocation.lua
+++ b/modules/phoenix/lua/Quests/Lost_in_Translocation.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- Module to remove exp and gil from 'Lost in Translocation' quest reward.
+-- Gil and exp were added to the quest reward in 2013 so they are removed here.
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_lost_in_translocation', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/crystalWar/Lost_in_Translocation', function(quest)
+        quest.reward = {
+            keyItem = xi.ki.MAP_OF_GRAUBERG,
+        }
+    end)
+end)

--- a/modules/phoenix/lua/Quests/One_Good_Deed.lua
+++ b/modules/phoenix/lua/Quests/One_Good_Deed.lua
@@ -1,0 +1,18 @@
+-----------------------------------
+-- Module to remove exp, gil, and fame from 'One Good Deed' quest reward.
+-- Gil and exp were added to the quest reward in 2013 so they are removed here.
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_one_good_deed', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/windurst/One_Good_Deed', function(quest)
+        quest.reward = {
+            keyItem = xi.ki.MAP_OF_THE_ATTOHWA_CHASM,
+            title   = xi.title.DEED_VERIFIER,
+        }
+    end)
+end)

--- a/modules/phoenix/lua/Quests/Paradise_Salvation_and_Maps.lua
+++ b/modules/phoenix/lua/Quests/Paradise_Salvation_and_Maps.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- Module to remove exp and gil from 'Paradise Salvation and Maps' quest reward.
+-- Gil and exp were added to the quest reward in 2013 so they are removed here.
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_paradise_salvation_and_maps', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/otherAreas/Paradise_Salvation_and_Maps', function(quest)
+        quest.reward = {
+            keyItem = xi.ki.MAP_OF_THE_SACRARIUM,
+        }
+    end)
+end)

--- a/modules/phoenix/lua/Quests/RQ4_His_Name_is_Valgeir.lua
+++ b/modules/phoenix/lua/Quests/RQ4_His_Name_is_Valgeir.lua
@@ -1,0 +1,23 @@
+-----------------------------------
+-- Module to remove exp, gil, and fame from 'His Name is Valgeir' quest reward.
+-- Gil and exp were added to the quest reward in 2013 so they are removed here.
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_rq4_his_name_is_valgeir', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/otherAreas/RQ4_His_Name_is_Valgeir', function(quest)
+        quest.reward = {
+            keyItem = xi.ki.MAP_OF_THE_TORAIMARAI_CANAL,
+        }
+
+        quest.sections[2][xi.zone.MHAURA].onEventFinish[88] = function(player, csid, option, npc)
+            if quest:complete(player) then
+                quest:setVar(player, 'DayCompleted', VanadielUniqueDay())
+            end
+        end
+    end)
+end)

--- a/modules/phoenix/lua/Quests/Rock_Bottom.lua
+++ b/modules/phoenix/lua/Quests/Rock_Bottom.lua
@@ -1,0 +1,23 @@
+-----------------------------------
+-- Module to remove the gil compensation given by 'Rock Bottom' when the player
+-- already holds the map key item.
+-- Gil was added in 2013 so it is removed here.
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_rock_bottom', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/ahtUrhgan/Rock_Bottom', function(quest)
+        quest.sections[2][xi.zone.MOUNT_ZHAYOLM].onEventFinish[9] = function(player, csid, option, npc)
+            if quest:complete(player) then
+                player:tradeComplete()
+                if not player:hasKeyItem(xi.ki.MAP_OF_MOUNT_ZHAYOLM) then
+                    npcUtil.giveKeyItem(player, xi.ki.MAP_OF_MOUNT_ZHAYOLM)
+                end
+            end
+        end
+    end)
+end)

--- a/modules/phoenix/lua/Quests/The_Antique_Collector.lua
+++ b/modules/phoenix/lua/Quests/The_Antique_Collector.lua
@@ -1,0 +1,18 @@
+-----------------------------------
+-- Module to remove exp, gil, and fame from 'The Antique Collector' quest reward.
+-- Gil and exp were added to the quest reward in 2013 so they are removed here.
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_the_antique_collector', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/jeuno/The_Antique_Collector', function(quest)
+        quest.reward = {
+            keyItem = xi.ki.MAP_OF_DELKFUTTS_TOWER,
+            title   = xi.title.TRADER_OF_ANTIQUITIES,
+        }
+    end)
+end)

--- a/modules/phoenix/lua/Quests/The_Bare_Bones.lua
+++ b/modules/phoenix/lua/Quests/The_Bare_Bones.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- Module to remove exp and fame from 'The Bare Bones' quest reward.
+-- Exp was added to the quest reward in 2013 so it is removed here.
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_the_bare_bones', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/bastok/The_Bare_Bones', function(quest)
+        quest.reward = {
+            keyItem = xi.ki.MAP_OF_THE_DANGRUF_WADI,
+        }
+    end)
+end)

--- a/modules/phoenix/lua/Quests/The_Flipside_of_Things.lua
+++ b/modules/phoenix/lua/Quests/The_Flipside_of_Things.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- Module to remove exp and gil from 'The Flipside of Things' quest reward.
+-- Gil and exp were added to the quest reward in 2013 so they are removed here.
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_the_flipside_of_things', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/crystalWar/The_Flipside_of_Things', function(quest)
+        quest.reward = {
+            keyItem = xi.keyItem.MAP_OF_VUNKERL_INLET,
+        }
+    end)
+end)

--- a/modules/phoenix/lua/Quests/The_Rescue.lua
+++ b/modules/phoenix/lua/Quests/The_Rescue.lua
@@ -1,0 +1,20 @@
+-----------------------------------
+-- Module to remove exp from 'The Rescue' quest reward, and correct the gil
+-- reward to 3,000.
+-- Gil and exp were added to the quest reward in 2013 so exp is removed and gil corrected here.
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_the_rescue', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/otherAreas/The_Rescue', function(quest)
+        quest.reward = {
+            keyItem = xi.ki.MAP_OF_THE_RANGUEMONT_PASS,
+            gil     = 3000,
+            title   = xi.title.HONORARY_CITIZEN_OF_SELBINA,
+        }
+    end)
+end)

--- a/modules/phoenix/lua/Quests/The_Sand_Charm.lua
+++ b/modules/phoenix/lua/Quests/The_Sand_Charm.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- Module to remove exp, gil, and fame from 'The Sand Charm' quest reward.
+-- Gil and exp were added to the quest reward in 2013 so they are removed here.
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_the_sand_charm', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/otherAreas/The_Sand_Charm', function(quest)
+        quest.reward = {
+            keyItem = xi.ki.MAP_OF_BOSTAUNIEUX_OUBLIETTE,
+        }
+    end)
+end)

--- a/modules/phoenix/lua/Quests/The_Weekly_Adventurer.lua
+++ b/modules/phoenix/lua/Quests/The_Weekly_Adventurer.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- Module to remove exp and gil from 'The Weekly Adventurer' quest reward.
+-- Gil and exp were added to the quest reward in 2013 so they are removed here.
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_the_weekly_adventurer', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/crystalWar/The_Weekly_Adventurer', function(quest)
+        quest.reward = {
+            keyItem = xi.keyItem.MAP_OF_FORT_KARUGO_NARUGO,
+        }
+    end)
+end)

--- a/modules/phoenix/lua/Quests/Unforgiven.lua
+++ b/modules/phoenix/lua/Quests/Unforgiven.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- Module to remove exp from 'Unforgiven' quest reward.
+-- Exp was added to the quest reward in 2013 so it is removed here.
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_unforgiven', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/otherAreas/Unforgiven', function(quest)
+        quest.reward = {
+            keyItem = xi.ki.MAP_OF_TAVNAZIA,
+        }
+    end)
+end)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Removes the OOE EXP and gil reward from map quests. 
A Smudge On One's Record and The Rescue do have gil rewards, but they are era accurate gil rewards.
<img width="1157" height="301" alt="image" src="https://github.com/user-attachments/assets/a0c85522-e95b-4913-8df3-38219ac83d06" />

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!additem bone_chip
!pos -175 2 -135 235
talk to him and then trade the bone chip
receive only the map instead of the map and 2000 exp
<!-- Clear and detailed steps to test your changes here -->
