### PR TITLE
[lua][module] Fixes no-auto attack on claimshield module

### DIFF
--- a/modules/custom/lua/claim_shield.lua
+++ b/modules/custom/lua/claim_shield.lua
@@ -365,7 +365,6 @@ end
 local endClaimShield = function(mob)
     mob:setUnkillable(false)
     mob:setCallForHelpBlocked(false)
-    mob:resetAI()
     mob:setHP(mob:getMaxHP())
 
     local mobId = mob:getID()
@@ -379,6 +378,20 @@ end
 -- Selects a winner, awards claim, notifies entrants, and clears enmity for losing entrants.
 local resolveLottery = function(mob, entries)
     mob:setMobMod(xi.mobMod.CLAIM_TYPE, xi.claimType.EXCLUSIVE)
+
+    for _, enmityEntry in pairs(mob:getEnmityList()) do
+        local entity = enmityEntry.entity
+        if entity then
+            if not entity:isPC() then
+                entity:disengage()
+            end
+
+            mob:resetEnmity(entity)
+        end
+    end
+
+    mob:resetAI()
+    mob:disengage()
 
     local entrantCount = #entries
     local claimWinner  = utils.randomEntry(entries)
@@ -395,16 +408,8 @@ local resolveLottery = function(mob, entries)
         winningMembers[member:getID()] = true
     end
 
-    for _, enmityEntry in pairs(mob:getEnmityList()) do
-        local entity = enmityEntry.entity
-        local player = entity:isPC() and entity or entity:getMaster()
-
-        if not player or not winningMembers[player:getID()] then
-            mob:clearEnmityForEntity(entity)
-        end
-    end
-
     mob:updateClaim(claimWinner)
+    mob:addEnmity(claimWinner, 1, 1)
 
     for _, member in pairs(alliance) do
         member:printToPlayer(winnerMessage, xi.msg.channel.SYSTEM_3, '')


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds disengage so the animation and enmity both reset so the mob does not get stuck anymore. Also forces disengage on pets just in case because fuck pets. Resets enmity as a precaution as well.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!gotoid 17101197
!spawnmob 17101197
stun it when it spawns
See it claims to you and hit you 
<!-- Clear and detailed steps to test your changes here -->
