### PR TITLE
fix(dbtool): scope incremental module imports

### DIFF
--- a/tools/ci/sanity_checks/python.sh
+++ b/tools/ci/sanity_checks/python.sh
@@ -41,4 +41,8 @@ for file in "${targets[@]}"; do
     fi
 done
 
+if ! python -m unittest discover -s tools/tests -p 'test_dbtool_*.py'; then
+    any_issues=true
+fi
+
 $any_issues && exit 1 || exit 0

--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -13,6 +13,8 @@ import urllib.request
 
 import platform
 
+from dbtool_modules import parse_module_entries, select_module_sql_files
+
 
 # Pre-flight sanity checks
 def preflight_exit():
@@ -370,17 +372,43 @@ def write_configs():
         yaml.dump(dump, file)
 
 
-def fetch_module_files():
+def fetch_module_files(express=False):
     with open(from_server_path("modules/init.txt"), "r", encoding="utf-8") as file:
-        for line in file.readlines():
-            if not line.startswith("#") and line.strip() and not line in ["\n", "\r\n"]:
-                line = from_server_path("modules/" + line.strip())
-                if pathlib.Path(line).is_dir():
-                    for filename in sorted(pathlib.Path(line).glob("**/*.sql")):
-                        import_files.append(str(filename).replace("\\", "/"))
-                else:
-                    if line.endswith(".sql"):
-                        import_files.append(str(line).replace("\\", "/"))
+        current_entries = parse_module_entries(file.read())
+
+    current_files = []
+    for entry in current_entries:
+        path = pathlib.Path(from_server_path("modules/" + entry))
+        if path.is_dir():
+            current_files.extend(sorted(path.glob("**/*.sql")))
+        elif path.suffix == ".sql":
+            current_files.append(path)
+
+    current_paths = [
+        path.relative_to(from_server_path("modules")).as_posix()
+        for path in current_files
+    ]
+    selected_paths = current_paths
+
+    if express:
+        module_diffs = repo.commit(db_ver).diff(
+            release_version, paths=from_server_path("modules/")
+        )
+        changed_paths = {
+            diff.b_path.replace("\\", "/").removeprefix("modules/")
+            for diff in module_diffs
+            if diff.b_path and diff.b_path.endswith(".sql")
+        }
+        previous_init = repo.git.show(f"{db_ver}:modules/init.txt")
+        previous_entries = parse_module_entries(previous_init)
+        selected_paths = select_module_sql_files(
+            current_paths, changed_paths, previous_entries
+        )
+
+    for path in selected_paths:
+        import_files.append(from_server_path("modules/" + path))
+
+    return bool(selected_paths)
 
 
 def check_protected():
@@ -456,7 +484,8 @@ def fetch_files(express=False):
         )
     except Exception:
         pass
-    fetch_module_files()
+    if fetch_module_files(express):
+        express_enabled = True
 
 
 def write_version(silent=False):

--- a/tools/dbtool_modules.py
+++ b/tools/dbtool_modules.py
@@ -1,0 +1,24 @@
+def parse_module_entries(contents):
+    entries = []
+    for line in contents.splitlines():
+        entry = line.strip()
+        if entry and not entry.startswith("#"):
+            entries.append(entry.replace("\\", "/").strip("/"))
+    return entries
+
+
+def module_path_enabled(path, entries):
+    normalized_path = path.replace("\\", "/").strip("/")
+    return any(
+        normalized_path == entry or normalized_path.startswith(entry + "/")
+        for entry in entries
+    )
+
+
+def select_module_sql_files(current_paths, changed_paths, previous_entries):
+    changed = {path.replace("\\", "/").strip("/") for path in changed_paths}
+    return sorted(
+        path
+        for path in current_paths
+        if path in changed or not module_path_enabled(path, previous_entries)
+    )

--- a/tools/tests/test_dbtool_modules.py
+++ b/tools/tests/test_dbtool_modules.py
@@ -1,0 +1,52 @@
+import unittest
+
+from tools.dbtool_modules import parse_module_entries, select_module_sql_files
+
+
+class ModuleSqlSelectionTests(unittest.TestCase):
+    def test_parses_enabled_module_entries(self):
+        contents = """
+        # Disabled module
+        phoenix/sql
+        custom/example.sql
+        """
+
+        self.assertEqual(
+            parse_module_entries(contents),
+            ["phoenix/sql", "custom/example.sql"],
+        )
+
+    def test_selects_only_changed_enabled_sql(self):
+        current_paths = [
+            "abyssea/sql/guild_item_points.sql",
+            "phoenix/sql/bazaar_tax.sql",
+        ]
+
+        selected = select_module_sql_files(
+            current_paths,
+            {"phoenix/sql/bazaar_tax.sql"},
+            ["abyssea/sql", "phoenix/sql"],
+        )
+
+        self.assertEqual(selected, ["phoenix/sql/bazaar_tax.sql"])
+
+    def test_selects_all_sql_from_newly_enabled_module(self):
+        current_paths = [
+            "abyssea/sql/guild_item_points.sql",
+            "phoenix/sql/bazaar_tax.sql",
+        ]
+
+        selected = select_module_sql_files(
+            current_paths,
+            set(),
+            ["phoenix/sql"],
+        )
+
+        self.assertEqual(
+            selected,
+            ["abyssea/sql/guild_item_points.sql"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- limit incremental dbtool runs to changed module SQL files
- import all SQL for modules newly enabled in `modules/init.txt`
- treat module-only SQL changes as database updates
- run focused dbtool module-selection tests in Python sanity checks

## Root cause
Incremental updates diffed core `sql/` files but then appended every enabled module SQL file. Unchanged module files containing plain inserts were replayed against existing tables, causing duplicate-key failures before the dbtool checkpoint could advance.

## Validation
- `py -3 -m unittest discover -s tools/tests -p 'test_dbtool_*.py'`
- `py -3 -m compileall -q tools/dbtool.py tools/dbtool_modules.py tools/tests/test_dbtool_modules.py`
- `phoenix build`
- reproduced the `af44c` to `f0d6db` update with `phoenix up map -d --nobuild --verbose`
- confirmed unchanged `modules/abyssea/sql/guild_item_points.sql` was not replayed
- confirmed changed/newly enabled module SQL imported successfully and the checkpoint advanced to `f0d6db`
- repeated the Phoenix CLI startup and confirmed `Database is up to date`