### PR TITLE
[lua] Remove drops if no xp from -1 mobs

### DIFF
--- a/modules/phoenix/lua/custom/pxi_launch_names.lua
+++ b/modules/phoenix/lua/custom/pxi_launch_names.lua
@@ -34,3 +34,32 @@ for zoneName, names in pairs(eventMobNames) do
         end
     end)
 end
+
+-- Stop starter mobs from granting items if killer gets no exp
+local starterMobs =
+{
+    West_Ronfaure     = { 'Wild_Rabbit',     'Tunnel_Worm' },
+    East_Ronfaure     = { 'Wild_Rabbit',     'Tunnel_Worm' },
+    North_Gustaberg   = { 'Huge_Hornet',     'Tunnel_Worm' },
+    South_Gustaberg   = { 'Huge_Hornet',     'Tunnel_Worm' },
+    West_Sarutabaruta = { 'Tiny_Mandragora', 'Bumblebee'   },
+    East_Sarutabaruta = { 'Tiny_Mandragora', 'Bumblebee'   },
+}
+
+for zoneName, mobNames in pairs(starterMobs) do
+    for _, mobName in ipairs(mobNames) do
+        m:addOverride(string.format('xi.zones.%s.mobs.%s.onMobDeath', zoneName, mobName), function(mob, player, optParams)
+            super(mob, player, optParams)
+
+            -- Only run for killer
+            if not optParams.isKiller then
+                return
+            end
+
+            -- No drops if killer does not get xp
+            if not player:checkKillCredit(mob) then
+                mob:setMobMod(xi.mobMod.NO_DROPS, 1)
+            end
+        end)
+    end
+end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Makes it so the 6 starter mobs can not grant items if the killer gains no xp in the module that boosts mob spawns.

## Steps to test these changes

Kill mobs at different levels
