### PR TITLE
[module] [lua] Pet EXP Module

### DIFF
--- a/modules/phoenix/lua/custom/pet_exp_penalty.lua
+++ b/modules/phoenix/lua/custom/pet_exp_penalty.lua
@@ -1,0 +1,39 @@
+-----------------------------------
+-- Phoenix Pet EXP Penalty Module
+--
+-- Parties of 3 or less will not be affected by this module.
+-- When 4 players are in the party, pets will only give 30% of their normal EXP (70% penalty).
+-- When 5 players are in the party, pets will only give 20% of their normal EXP (80% penalty).
+-- When 6 or more players are in the party/alliance, pets will only give 10% of their normal EXP (90% penalty).
+-----------------------------------
+require('modules/module_utils')
+
+local m = Module:new('pet_exp_penalty')
+
+-- Percent of exp removed per party size. Sizes past the table use the last entry.
+local penaltyBySize =
+{
+    [4] = 70,
+    [5] = 80,
+    [6] = 90,
+}
+
+m:addOverride('xi.experiencePoints.calculate', function(member, mob, data)
+    local result = super(member, mob, data)
+
+    if not result or data.partySize < 4 then
+        return result
+    end
+
+    -- Only pets owned by another monster. Charmed pets and player jug pets have
+    -- a player master and keep full value.
+    local master = mob:getMaster()
+    if not master or not master:isMob() then
+        return result
+    end
+
+    local penalty = penaltyBySize[math.min(data.partySize, 6)]
+    result.exp = math.floor(result.exp * (100 - penalty) / 100)
+
+    return result
+end)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adds a custom module that cuts the EXP awarded for killing another monster's pet when the killing party has more than 3 members. Parties of 3 or fewer are untouched. At 4 members pets give 30% of their normal value, (70% penalty) at 5 members 20% (80% penalty), and at 6 or more 10% (90% penalty).

"Pet" means a mob with an actual master link (everything wired up through xi.pet.setMobPet), so beastmen jug pets, wyverns, avatars, and elementals are included. Adds spawned as loose helpers through callPets have no master and are not affected.
Player-owned pets are excluded. Charmed mobs and jug pets have a player master, and the module checks that the master is a mob before touching anything.

Also, if you engage a pet with 4-6 in your party and then people drop, the penalty is still not avoided. It is calculated base don the party size you had on engage.

## Steps to test these changes

Load the module. Kills pets as a party of 3 and see its normal. Kill as a party of 4-6 and see your EXP is severely reduced.