### PR TITLE
[module] [lua] Add more NMs to Claimshield

### DIFF
--- a/modules/custom/lua/claim_shield.lua
+++ b/modules/custom/lua/claim_shield.lua
@@ -10,31 +10,65 @@ local claimshieldTime = 5000 -- Milliseconds.
 -- Entries may be a mob name or { name = 'Mob_Name', time = milliseconds }.
 local shieldedEntities =
 {
+    ['AlTaieu'] =
+    {
+        'Omyovra',
+        'Ulyovra',
+    },
+
+    ['Arrapago_Reef'] =
+    {
+        'Lamia_No19',
+    },
+
     ['Attohwa_Chasm'] =
     {
         'Citipati',
         'Tiamat',
         'Xolotl',
+        'Ambusher_Antlion',
+    },
+
+    ['Aydeewa_Subterrane'] =
+    {
+        'Bluestreak_Gyugyuroon',
     },
 
     ['Batallia_Downs'] =
     {
         'Lumber_Jack',
+        'Ahtu',
+        'Tottering_Toby',
+        'Weeping_Willow',
     },
 
     ['Beadeaux'] =
     {
         'GaBhu_Unvanquished',
+        'BiGho_Headtaker',
+        'DaDha_Hundredmask',
+        'DeVyu_Headhunter',
+        'GeDha_Evileye',
+        'GoBhu_Gascon',
+        'ZoKhu_Blackcloud',
     },
 
     ['Beaucedine_Glacier'] =
     {
         'Nue',
+        'Gargantua',
+        'Kirata',
+    },
+
+    ['Bhaflau_Thickets'] =
+    {
+        'Emergent_Elm',
     },
 
     ['Bibiki_Bay'] =
     {
         'Intulo',
+        'Serra',
     },
 
     ['Bostaunieux_Oubliette'] =
@@ -43,16 +77,33 @@ local shieldedEntities =
         'Drexerion_the_Condemned',
         'Phanduron_the_Condemned',
         'Sewer_Syrup',
+        'Arioch',
+        'Manes',
+        'Shii',
+    },
+
+    ['Buburimu_Peninsula'] =
+    {
+        'Buburimboo',
+        'Helldiver',
     },
 
     ['Caedarva_Mire'] =
     {
         'Khimaira',
+        'Peallaidh',
+        'Zikko',
     },
 
     ['Cape_Teriggan'] =
     {
         'Kreutzet',
+        'Frostmane',
+    },
+
+    ['Carpenters_Landing'] =
+    {
+        'Orctrap',
     },
 
     ['Castle_Oztroja'] =
@@ -60,6 +111,11 @@ local shieldedEntities =
         'Mee_Deggi_the_Punisher',
         'Quu_Domi_the_Gallant',
         'Tzee_Xicu_the_Manifest',
+        'Moo_Ouzi_the_Swiftblade',
+        'Yaa_Haqa_the_Profane',
+        'Yagudo_Avatar',
+        'Yagudo_High_Priest',
+        'Yagudo_Templar',
     },
 
     ['Castle_Zvahl_Baileys'] =
@@ -70,9 +126,32 @@ local shieldedEntities =
         'Marquis_Amon',
     },
 
+    ['Castle_Zvahl_Keep'] =
+    {
+        'Baron_Vapula',
+        'Baronet_Romwe',
+        'Count_Bifrons',
+        'Viscount_Morax',
+    },
+
     ['Crawlers_Nest'] =
     {
         'Demonic_Tiphia',
+    },
+
+    ['Dangruf_Wadi'] =
+    {
+        'Geyser_Lizard',
+    },
+
+    ['Davoi'] =
+    {
+        'Blubbery_Bulge',
+        'Dirtyhanded_Gochakzuk',
+        'Hawkeyed_Dnatbat',
+        'Poisonhand_Gnadgad',
+        'Steelbiter_Gudrud',
+        'Tigerbane_Bakdak',
     },
 
     ['Den_of_Rancor'] =
@@ -80,16 +159,32 @@ local shieldedEntities =
         'Friar_Rush',
         'Tonberry_Decapitator',
         'Tonberry_Tracker',
+        'Bistre-hearted_Malberry',
+        'Carmine-tailed_Janberry',
+        'Celeste-eyed_Tozberry',
+        'Ogama',
+        'Sozu_Bliberry',
+        'Tawny-fingered_Mugberry',
+        'Tonberry_Pontifex',
+    },
+
+    ['East_Ronfaure'] =
+    {
+        'Bigmouth_Billy',
+        'Swamfisk',
     },
 
     ['East_Sarutabaruta'] =
     {
         'Spiny_Spipi',
+        'Sharp-Eared_Ropipi',
     },
 
     ['Eastern_Altepa_Desert'] =
     {
         'Centurio_XII-I',
+        'Cactrot_Rapido',
+        'Dune_Widow',
     },
 
     ['FeiYin'] =
@@ -99,28 +194,75 @@ local shieldedEntities =
         'Northern_Shadow',
         'Southern_Shadow',
         'Western_Shadow',
+        'Goliath',
+    },
+
+    ['Fort_Ghelsba'] =
+    {
+        'Hundredscar_Hajwaj',
+        'Orcish_Panzer',
     },
 
     ['Garlaige_Citadel'] =
     {
         'Serket',
+        'Old_Two-Wings',
+        'Skewer_Sam',
     },
 
     ['Giddeus'] =
     {
         'Hoo_Mjuu_the_Torrent',
+        'Eyy_Mon_the_Ironbreaker',
+        'Juu_Duzu_the_Whirlwind',
+        'Vuu_Puqu_the_Beguiler',
+        'Zhuu_Buxu_the_Silent',
+    },
+
+    ['Gusgen_Mines'] =
+    {
+        'Asphyxiated_Amsel',
+        'Burned_Bergmann',
+        'Crushed_Krause',
+        'Juggler_Hecatomb',
+        'Pulverized_Pfeffer',
+        'Smothered_Schmidt',
+        'Wounded_Wurfel',
     },
 
     ['Gustav_Tunnel'] =
     {
         'Amikiri',
         'Bune',
+        'Baobhan_Sith',
+        'Goblinsavior_Heronox',
+        'Taxim',
+        'Ungur',
+        'Wyvernpoacher_Drachlox',
+    },
+
+    ['Ifrits_Cauldron'] =
+    {
+        'Ash_Dragon',
+        'Foreseer_Oramix',
+        'Lindwurm',
+        'Tyrannic_Tunnok',
+        'Vouivre',
+    },
+
+    ['Inner_Horutoto_Ruins'] =
+    {
+        'Maltha',
+        'Slendlix_Spindlethumb',
     },
 
     ['Jugner_Forest'] =
     {
         'King_Arthro',
         'Panzer_Percival',
+        'Fradubio',
+        'Fraelissa',
+        'Meteormauler_Zhagtegg',
     },
 
     ['King_Ranperres_Tomb'] =
@@ -134,22 +276,34 @@ local shieldedEntities =
     {
         'Steelfleece_Baldarich',
         'Stray_Mary',
+        'Bendigeit_Vran',
+        'Haty',
+        'Rampaging_Ram',
     },
 
     ['Korroloka_Tunnel'] =
     {
         'Cargo_Crab_Colin',
+        'Dame_Blanche',
+        'Falcatus_Aranei',
     },
 
     ['Kuftal_Tunnel'] =
     {
         'Amemet',
         'Yowie',
+        'Arachne',
+        'Bloodthirster_Madkix',
+        'Guivre',
+        'Pelican',
+        'Sabotender_Mariachi',
     },
 
     ['La_Theine_Plateau'] =
     {
         'Bloodtear_Baldurf',
+        'Lumbering_Lambert',
+        'Tumbling_Truffle',
     },
 
     ['Labyrinth_of_Onzozo'] =
@@ -157,18 +311,53 @@ local shieldedEntities =
         'Lord_of_Onzozo',
         'Mysticmaker_Profblix',
         'Ose',
+        'Hellion',
+        'Narasimha',
+        'Peg_Powler',
+        'Soulstealer_Skullnix',
+    },
+
+    ['Lower_Delkfutts_Tower'] =
+    {
+        'Epialtes',
+        'Eurymedon',
+        'Hippolytos',
     },
 
     ['Lufaise_Meadows'] =
     {
         'Padfoot',
         'Megalobugard',
+        'Colorful_Leshy',
+        'Defoliate_Leshy',
+    },
+
+    ['Mamook'] =
+    {
+        'Zizzy_Zillah',
     },
 
     ['Maze_of_Shakhrami'] =
     {
         'Argus',
         'Leech_King',
+    },
+
+    ['Meriphataud_Mountains'] =
+    {
+        'Coo_Keja_the_Unseen',
+        'Daggerclaw_Dracos',
+        'Waraxe_Beak',
+    },
+
+    ['Middle_Delkfutts_Tower'] =
+    {
+        'Eurytos',
+        'Ogygos',
+        'Ophion',
+        'Polybotes',
+        'Rhoikos',
+        'Rhoitos',
     },
 
     ['Misareaux_Coast'] =
@@ -180,11 +369,31 @@ local shieldedEntities =
     ['Monastic_Cavern'] =
     {
         'Overlord_Bakgodek',
+        'Orcish_Hexspinner',
+        'Orcish_Overlord',
+        'Orcish_Warlord',
     },
 
     ['Mount_Zhayolm'] =
     {
         'Cerberus',
+        'Energetic_Eruca',
+    },
+
+    ['Newton_Movalpolos'] =
+    {
+        'Swashstox_Beadblinker',
+    },
+
+    ['North_Gustaberg'] =
+    {
+        'Maighdean_Uaine',
+        'Stinging_Sophie',
+    },
+
+    ['Oldton_Movalpolos'] =
+    {
+        'Bugbear_Strongman',
     },
 
     ['Ordelles_Caves'] =
@@ -192,25 +401,104 @@ local shieldedEntities =
         'Morbolger',
     },
 
+    ['Outer_Horutoto_Ruins'] =
+    {
+        'Bomb_King',
+        'Doppelganger_Dio',
+        'Doppelganger_Gog',
+    },
+
+    ['Palborough_Mines'] =
+    {
+        'BuGhi_Howlblade',
+        'NoMho_Crimsonarmor',
+        'ZiGhi_Boneeater',
+    },
+
+    ['Pashhow_Marshlands'] =
+    {
+        'Bloodpool_Vorax',
+        'BoWho_Warmonger',
+        'Jolly_Green',
+    },
+
+    ['Phanauet_Channel'] =
+    {
+        'Stubborn_Dredvodd',
+        'Vodyanoi',
+    },
+
+    ['Phomiuna_Aqueducts'] =
+    {
+        'Eba',
+        'Mahisha',
+        'Tres_Duendes',
+    },
+
     ['Promyvion-Dem'] =
     {
         'Satiator',
+    },
+
+    ['Promyvion-Holla'] =
+    {
+        'Cerebrator',
+    },
+
+    ['Promyvion-Mea'] =
+    {
+        'Coveter',
+    },
+
+    ['PsoXja'] =
+    {
+        'Gyre-Carlin',
+    },
+
+    ['Qufim_Island'] =
+    {
+        'Dosetsu_Tree',
+        'Trickster_Kinetix',
     },
 
     ['Quicksand_Caves'] =
     {
         'Centurio_X-I',
         'Sabotender_Bailarina',
+        'Antican_Consul',
+        'Antican_Legatus',
+        'Antican_Magister',
+        'Antican_Praefectus',
+        'Antican_Praetor',
+        'Antican_Proconsul',
+        'Antican_Tribunus',
+        'Diamond_Daig',
+        'Hastatus_XI-XII',
+        'Nussknacker',
+        'Proconsul_XII',
+        'Sabotender_Bailarin',
+        'Sagittarius_X-XIII',
+        'Triarius_X-XV',
     },
 
     ['Qulun_Dome'] =
     {
         'ZaDha_Adamantking',
+        'Adaman_Quadav',
+        'Diamond_Quadav',
+        'Ruby_Quadav',
+    },
+
+    ['Ranguemont_Pass'] =
+    {
+        'Taisaijin',
     },
 
     ['Riverne-Site_A01'] =
     {
         'Carmine_Dobsonfly',
+        'Aiatar',
+        'Heliodromos',
     },
 
     ['Riverne-Site_B01'] =
@@ -222,6 +510,9 @@ local shieldedEntities =
     {
         -- 'Eldritch_Edge',
         'Simurgh',
+        'Black_Triple_Stars',
+        'Drooling_Daisy',
+        'Silk_Caterpillar',
     },
 
     ['Rolanberry_Fields_[S]'] =
@@ -232,6 +523,7 @@ local shieldedEntities =
     ['RoMaeve'] =
     {
         'Shikigami_Weapon',
+        'Nightmare_Vase',
     },
 
     ['Sacrarium'] =
@@ -243,6 +535,7 @@ local shieldedEntities =
     {
         -- 'Blighting_Brand',
         'Roc',
+        'Deadly_Dodo',
     },
 
     ['Sauromugue_Champaign_[S]'] =
@@ -256,6 +549,21 @@ local shieldedEntities =
         'Fyuu_the_Seabellow',
         'Novv_the_Whitehearted',
         'Sea_Hog',
+        'Abyss_Sahagin',
+        'Coral_Sahagin',
+        'Denn_the_Orcavoiced',
+        'Masan',
+        'Mouu_the_Waverider',
+        'Namtar',
+        'Ocean_Sahagin',
+        'Pahh_the_Gullcaller',
+        'Qull_the_Shellbuster',
+        'Seww_the_Squidlimbed',
+        'Voll_the_Sharkfinned',
+        'Worr_the_Clawfisted',
+        'Wuur_the_Sandcomber',
+        'Yarr_the_Pearleyed',
+        'Zuug_the_Shoreleaper',
     },
 
     ['South_Gustaberg'] =
@@ -264,21 +572,45 @@ local shieldedEntities =
         'Carnero',
     },
 
+    ['Tahrongi_Canyon'] =
+    {
+        'Serpopard_Ishtar',
+    },
+
     ['Temple_of_Uggalepih'] =
     {
         'Sozu_Sarberry',
         'Sozu_Terberry',
+        'Bonze_Marberry',
+        'Flauros',
+        'Manipulator',
+        'Tonberry_Kinq',
     },
 
     ['The_Boyahda_Tree'] =
     {
         'Voluptuous_Vivian',
         'Ancient_Goobbue',
+        'Aquarius',
+        'Ellyllon',
+        'Leshonki',
+        'Unut',
+    },
+
+    ['The_Eldieme_Necropolis'] =
+    {
+        'Cwn_Cyrff',
+    },
+
+    ['The_Garden_of_RuHmet'] =
+    {
+        'Ixaern_DRG',
     },
 
     ['The_Sanctuary_of_ZiTah'] =
     {
         'Noble_Mold',
+        'Keeper_of_Halidom',
     },
 
     ['The_Shrine_of_RuAvitau'] =
@@ -287,20 +619,38 @@ local shieldedEntities =
         'Mother_Globe',
     },
 
+    ['Toraimarai_Canal'] =
+    {
+        'Oni_Carcass',
+    },
+
     ['Uleguerand_Range'] =
     {
         'Jormungand',
         'Bonnacon',
+        'Father_Frost',
+        'Mountain_Worm_NM',
+        'Snow_Maiden',
+    },
+
+    ['Upper_Delkfutts_Tower'] =
+    {
+        'Enkelados',
+        'Ixtab',
+        'Mimas',
+        'Porphyrion',
     },
 
     ['Valkurm_Dunes'] =
     {
         'Valkurm_Emperor',
+        'Golden_Bat',
     },
 
     ['VeLugannon_Palace'] =
     {
         'Zipacna',
+        'Steam_Cleaner',
     },
 
     ['Wajaom_Woodlands'] =
@@ -310,25 +660,53 @@ local shieldedEntities =
         'Zoraal_Jas_Pkuucha',
     },
 
+    ['West_Ronfaure'] =
+    {
+        'Fungus_Beetle',
+        'Jaggedy-Eared_Jack',
+    },
+
+    ['West_Sarutabaruta'] =
+    {
+        'Nunyenunc',
+        'Tom_Tit_Tat',
+    },
+
     ['Western_Altepa_Desert'] =
     {
         'King_Vinegarroon',
+        'Cactuar_Cantautor',
+        'Celphie',
     },
 
     ['Xarcabard'] =
     {
         'Biast',
+        'Boreal_Coeurl',
+        'Boreal_Hound',
+        'Boreal_Tiger',
+        'Ereshkigal',
+        'Shadow_Eye',
     },
 
     ['Yhoator_Jungle'] =
     {
         'Bright-handed_Kunberry',
+        'Bisque-heeled_Sunberry',
+        'Woodland_Sage',
+    },
+
+    ['Yughott_Grotto'] =
+    {
+        'Ashmaker_Gotblut',
     },
 
     ['Yuhtunga_Jungle'] =
     {
         'Rose_Garden',
         'Voluptuous_Vilma',
+        'Meww_the_Turtlerider',
+        'Mischievous_Micholas',
     },
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adds many new NMs to claim shield. Essentially every world spawn mob should now be included. Of course, quest mobs, mission mobs, pop mobs, and other mobs that shouldn't have claim shields are excluded. I included Steam Cleaner because he pops unclaimed.

## Steps to test these changes

See more mobs have claim shield now.