### PR TITLE
[cpp] Rework tester gear module with item transaction change

### DIFF
--- a/modules/phoenix/cpp/tester_gear.cpp
+++ b/modules/phoenix/cpp/tester_gear.cpp
@@ -9,9 +9,8 @@
  ************************************************************************/
 
 #include "map/entities/char_entity.h"
-#include "map/item_container.h"
+#include "map/items/transactions/item_claim.h"
 #include "map/lua/lua_base_entity.h"
-#include "map/utils/charutils.h"
 #include "map/utils/moduleutils.h"
 
 class TesterGearModule : public CPPModule
@@ -31,7 +30,13 @@ class TesterGearModule : public CPPModule
                              uint32 quantity = qty.value_or(1);
                              bool   silence  = silent.value_or(false);
 
-                             return charutils::AddItem(PChar, locationId, itemId, quantity, silence) != ERROR_SLOTID;
+                             auto transaction = ItemClaimTransaction::start(PChar);
+                             if (!transaction)
+                             {
+                                 return false;
+                             }
+
+                             return transaction->give(locationId, itemId, quantity, Silence(silence)).has_value() && transaction->commit();
                          });
     }
 };


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Reworks tester gear CPP module to utilize item transactions due to the removal of charutils::AddItem

