### PR TITLE
[Phoenix] Anniversary Ring for New Characters

### DIFF
--- a/modules/phoenix/lua/quests/hiddenquests/anniversary_ring.lua
+++ b/modules/phoenix/lua/quests/hiddenquests/anniversary_ring.lua
@@ -1,0 +1,47 @@
+-----------------------------------
+-- Module: Anniversary Ring for New Characters
+-- Hands out an Anniversary Ring with the Adventurer's Coupon at the end of the opening cutscene.
+-- Changing nations replays that cutscene, so only a character's first viewing grants the ring.
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('anniversary_ring')
+
+local introEvents =
+{
+    [xi.zone.BASTOK_MARKETS]     = 7,
+    [xi.zone.BASTOK_MINES]       = 1,
+    [xi.zone.PORT_BASTOK]        = 1,
+    [xi.zone.NORTHERN_SAN_DORIA] = 535,
+    [xi.zone.SOUTHERN_SAN_DORIA] = 503,
+    [xi.zone.PORT_SAN_DORIA]     = 500,
+    [xi.zone.WINDURST_WATERS]    = 531,
+    [xi.zone.WINDURST_WOODS]     = 367,
+    [xi.zone.PORT_WINDURST]      = 305,
+}
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/hiddenQuests/New_Character_Cutscenes', function(quest)
+        for zoneId, eventId in pairs(introEvents) do
+            local zoneSection = quest.sections[1][zoneId]
+            local baseHandler = zoneSection and zoneSection.onEventFinish[eventId]
+
+            -- A missing handler would leave the whole cutscene unregistered, taking the coupon with it.
+            if baseHandler then
+                zoneSection.onEventFinish[eventId] = function(player, csid, option, npc)
+                    -- The base handler marks the nation, so the first viewing is read ahead of it.
+                    local firstViewing = quest:getVar(player, 'nations') == 0
+                    local result       = baseHandler(player, csid, option, npc)
+
+                    if firstViewing then
+                        npcUtil.giveItem(player, xi.item.ANNIVERSARY_RING)
+                    end
+
+                    return result
+                end
+            end
+        end
+    end)
+end)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adds an anniversary ring to every new character upon the end of the starter cutscene. It also blocks character who obtained one previously from getting another one when they swap nations and see the first time CS. The ring is only granted to legitimately new characters, and only one time.

## Steps to test these changes

Load the module and see all of the above.
