### PR TITLE
[Phoenix] Assault Promotion Block Module

### DIFF
--- a/modules/phoenix/lua/quests/promotion_quest_block.lua
+++ b/modules/phoenix/lua/quests/promotion_quest_block.lua
@@ -1,0 +1,34 @@
+-----------------------------------
+-- Module: Mercenary Promotion Block
+-- Currently blocking promotion past Lance Corporal. To be updated per Phoenix patch release.
+-- No Promotion: Captain block yet because the quest is not yet implemented, so it cannot be called.
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('promotion_quest_block')
+
+-- Every quest in the chain, so a GM-flagged one goes nowhere either.
+local blockedQuests =
+{
+    'scripts/quests/ahtUrhgan/Promotion_Corporal',
+    'scripts/quests/ahtUrhgan/Promotion_Sergeant',
+    'scripts/quests/ahtUrhgan/Promotion_Sergeant_Major',
+    'scripts/quests/ahtUrhgan/Promotion_Chief_Sergeant',
+    'scripts/quests/ahtUrhgan/Promotion_Second_Lieutenant',
+    'scripts/quests/ahtUrhgan/Promotion_First_Lieutenant',
+}
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    for _, questPath in ipairs(blockedQuests) do
+        xi.module.modifyInteractionEntry(questPath, function(quest)
+            -- Every section, not just the offer. First Lieutenant is offered by a trigger area with no NPC key.
+            for _, section in ipairs(quest.sections) do
+                section.check = function()
+                    return false
+                end
+            end
+        end)
+    end
+end)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR stops players from being able to rank up past Lance Corporal. We will launch with two tiers of assaults - Private First Class and Superior Private. However, we want to give players the option to earn credits while Superior Private and rank up. This means players will be able to achieve Lance Corporal rank, which gives them longer Sanction, but they will not be able to do Lance Corporal assaults until we enable them.

This PR functions by outright blocking access to all of the quests to be safe. Note that Promotion: Captain is not implemented in LSB yet so it is not listed here. It is not a risk because you also need to have completed TOAU 48, which will not be possible. 

This module will be updated over time as we add new assault ranks. The plan is to let players rank up one tier further than the level of assaults we currently offer.

## Steps to test these changes

Load the module. Get Lance Corporal. Get 25 assault points. See you can't begin the next quest. 
