### PR TITLE
[lua] Fix Warp Cudgel Griefing Players

### DIFF
--- a/modules/phoenix/lua/items/era_items.lua
+++ b/modules/phoenix/lua/items/era_items.lua
@@ -56,9 +56,3 @@ m:addOverride('xi.items.anniversary_ring.onItemUse', function(target)
 
     xi.itemUtils.addItemExpEffect(target, effect, power, duration, subpower)
 end)
-
--- Warp Cudgel
--- Duration: 3 seconds - > 30 seconds
-m:addOverride('xi.items.warp_cudgel.onItemUse', function(target, user)
-    target:addStatusEffect(xi.effect.TELEPORT, { power = xi.teleport.id.WARP, duration = 30, origin = user, icon = 0 })
-end)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a mistake where a massive delay was being added to the warp animation of warp cudgel, causing it to warp you out 30s later

## Steps to test these changes
Use a Warp Cudgel, actually warp