### PR TITLE
[sql] OOE Item equipment adjustment module

### DIFF
--- a/modules/phoenix/sql/pxi_item_equipment.sql
+++ b/modules/phoenix/sql/pxi_item_equipment.sql
@@ -1,0 +1,49 @@
+-- ------------------------------------------------------------
+-- Item Equipment Changes that require a DAT edit to change
+-- ------------------------------------------------------------
+
+-- Shields and PLD/DRK gear: remove WAR access added in the May 2015 update
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 12306;  -- Kite Shield
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 12307;  -- Heater Shield
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 12308;  -- Darksteel Shield
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 12309;  -- Ritter Shield
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 12312;  -- R.K. Army Shield
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 12313;  -- T.K. Army Shield
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 12321;  -- Ryl.Grd. Shield
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 12323;  -- Scutum
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 12324;  -- Tower Shield
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 12326;  -- Kite Shield +1
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 12328;  -- Heater Shield +1
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 12339;  -- Scutum +1
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 12346;  -- Dst. Shield +1
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 12354;  -- Tower Shield +1
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 12358;  -- Ritter Shield +1
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 12368;  -- R.K. Shield +1
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 12369;  -- R.K. Shield +2
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 12376;  -- T.K. Shield +1
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 12377;  -- T.K. Shield +2
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 12381;  -- Charging Shield
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 12383;  -- General's Shield
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 12384;  -- Admiral's Shield
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 12405;  -- Jennet Shield
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 15000;  -- Caballero Gnt.
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 16161;  -- Januwiyah
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 16163;  -- Januwiyah +1
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 16166;  -- Januwiyah -1
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 16169;  -- Caballero Shield
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 16170;  -- Wivre Shield
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 16171;  -- Wivre Shield +1
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 16172;  -- Iron Ram Shield
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 16174;  -- Riot Shield
+UPDATE `item_equipment` SET `jobs` = 192 WHERE `itemId` = 16181;  -- Terror Shield
+
+-- Removes mage jobs added to Flame Shield. WAR RDM PLD BST SAM only.
+UPDATE `item_equipment` SET `jobs` = 2385 WHERE `itemId` = 12317;
+
+-- Ammo: restore job-restricted lists (opened to all jobs out of our era)
+UPDATE `item_equipment` SET `jobs` = 7665 WHERE `itemId` = 17318;  -- Wooden Arrow (WAR RDM THF PLD DRK BST RNG SAM NIN)
+UPDATE `item_equipment` SET `jobs` = 1153 WHERE `itemId` = 17336;  -- Crossbow Bolt (WAR DRK RNG)
+UPDATE `item_equipment` SET `jobs` = 70688 WHERE `itemId` = 17343; -- Bronze Bullet (THF RNG NIN COR)
+
+-- Sets Knuckle of Trial to be MNK only (Removes PUP)
+UPDATE `item_equipment` SET `jobs` = 2 WHERE `itemId` = 17507;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Item module to adjust the following equippable gear:
  - Many shield had WAR added to them in 2015. Flame shield removes certain mage jobs added in an OOE patch.
  - Reverts several lvl 1 ammo pieces to only be equippable by specific jobs
  - Knuckle of Trials only equippable by MNK.

## Steps to test these changes

- Load module and load into test server with no DAT edits loaded
- Change job to WAR
- !additem 12306
- See that you cannot equip the shield
