### PR TITLE
[lua] Disable certain Astral Candescense bonuses

### DIFF
--- a/modules/phoenix/lua/globals/disable_sanction_bonuses.lua
+++ b/modules/phoenix/lua/globals/disable_sanction_bonuses.lua
@@ -1,0 +1,42 @@
+-----------------------------------
+-- Phoenix Sanction Bonus Removal Module
+--
+-- Sanction is granted bare: the NPC never offers the regen, refresh or meal duration choice,
+-- and the effect carries no experience point bonus.
+-----------------------------------
+require('modules/module_utils')
+
+local m = Module:new('disable_sanction_bonuses')
+
+m:addOverride('xi.besieged.onTrigger', function(player, npc, eventBase)
+    local mercenaryRank = xi.besieged.getMercenaryRank(player)
+
+    if mercenaryRank == 0 then
+        player:startEvent(eventBase + 1, npc)
+        return
+    end
+
+    local maps = bit.bor(
+        player:hasKeyItem(xi.ki.MAP_OF_MAMOOK) and 1 or 0,
+        player:hasKeyItem(xi.ki.MAP_OF_HALVUNG) and 2 or 0,
+        player:hasKeyItem(xi.ki.MAP_OF_ARRAPAGO_REEF) and 4 or 0)
+
+    player:startEvent(eventBase, player:getCurrency('imperial_standing'), maps + xi.besieged.cipherValue(), mercenaryRank, 0, 0, 0, 0, 0)
+end)
+
+-- Prevent potential workarounds to access the sanction bonuses by overriding the option
+m:addOverride('xi.besieged.onEventFinish', function(player, csid, option, npc)
+    if
+        option == 16 or
+        option == 32 or
+        option == 48
+    then
+        option = 0
+    end
+
+    super(player, csid, option, npc)
+end)
+
+m:addOverride('xi.experiencePoints.getSanctionBonus', function(member, regionId)
+    return 0
+end)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Due to Besieged not functioning yet, we are disabling certain bonuses granted from having the astral candescence since you cannot lose it:
   - Regen / Refresh/ Meal Duration bonuses are not offered by Sanction NPCs.
   - No bonus experience is granted in ToAU areas with sanction effect

## Steps to test these changes

- Try out the bonuses, see you don't get them
