### PR TITLE
[yaml, lua] Phoenix droplist adjustments

### DIFF
--- a/modules/init.txt
+++ b/modules/init.txt
@@ -51,6 +51,7 @@ custom/cpp/ah_pagination.cpp
 
 # YAML
 era/data
+phoenix/data
 
 # Lua
 custom/lua/garrison_placeholder_data.lua

--- a/modules/phoenix/data/zones/behemoths_dominion/mobs.yaml
+++ b/modules/phoenix/data/zones/behemoths_dominion/mobs.yaml
@@ -1,0 +1,16 @@
+# Behemoth drops Savory Shank at uncommon instead of rare.
+
+templates:
+  Behemoth:
+    loot:
+      drops:
+        - chance: very_common
+          item:   behemoth_hide
+        - chance: very_common
+          item:   behemoth_hide
+        - chance: uncommon
+          item:   savory_shank
+        - chance: always
+          one_of:
+            thundercloud: 90
+            comet_tail:   10

--- a/modules/phoenix/data/zones/dragons_aery/mobs.yaml
+++ b/modules/phoenix/data/zones/dragons_aery/mobs.yaml
@@ -1,0 +1,38 @@
+# Fafnir drops Cup of Sweet Tea at uncommon and Ridill at rare.
+
+templates:
+  Fafnir:
+    loot:
+      drops:
+        - chance: always
+          item:   dragon_talon
+        - chance: common
+          item:   aegishjalmr
+        - chance: very_common
+          item:   handful_of_dragon_scales
+        - chance: very_common
+          item:   handful_of_dragon_scales
+        - chance: common
+          item:   dragon_heart
+        - chance: uncommon
+          item:   balmung
+        - chance: uncommon
+          item:   hrotti
+        - chance: uncommon
+          item:   cup_of_sweet_tea
+        - chance: always
+          one_of:
+            andvaranauts: 95
+            ridill: 5
+        - chance: always
+          one_of:
+            neptunal_abjuration_head:  31
+            aquarian_abjuration_feet:  23
+            aquarian_abjuration_hands: 23
+            earthen_abjuration_hands:  23
+        - chance: uncommon
+          one_of:
+            neptunal_abjuration_head:  31
+            aquarian_abjuration_feet:  23
+            aquarian_abjuration_hands: 23
+            earthen_abjuration_hands:  23

--- a/modules/phoenix/data/zones/valley_of_sorrows/mobs.yaml
+++ b/modules/phoenix/data/zones/valley_of_sorrows/mobs.yaml
@@ -1,0 +1,20 @@
+# Adamantoise drops Clump of Red Pondweed at uncommon instead of rare.
+
+templates:
+  Adamantoise:
+    loot:
+      drops:
+        - chance: always
+          item:   chunk_of_adaman_ore
+        - chance: very_common
+          item:   chunk_of_adaman_ore
+        - chance: common
+          item:   chunk_of_adaman_ore
+        - chance: common
+          item:   chunk_of_adaman_ore
+        - chance: uncommon
+          item:   sipar
+        - chance: rare
+          item:   heavy_cuirass
+        - chance: uncommon
+          item:   clump_of_red_pondweed

--- a/modules/phoenix/data/zones/western_altepa_desert/mobs.yaml
+++ b/modules/phoenix/data/zones/western_altepa_desert/mobs.yaml
@@ -1,0 +1,12 @@
+# King Vinegarroon drops Ace's Helm at very common instead of common.
+
+templates:
+  King_Vinegarroon:
+    loot:
+      drops:
+        - chance: very_common
+          item:   aces_helm
+        - chance: uncommon
+          item:   venomous_claw
+        - chance: uncommon
+          item:   heavy_shell

--- a/modules/phoenix/lua/battlefields/up_in_arms_kraken_club.lua
+++ b/modules/phoenix/lua/battlefields/up_in_arms_kraken_club.lua
@@ -1,0 +1,36 @@
+-----------------------------------
+-- Up in Arms Kraken Club Drop Rate
+-- Raises the Kraken Club roll from 1/10000 to 10/10000
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('up_in_arms_kraken_club')
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    local content = xi.battlefield.contents[xi.battlefield.id.UP_IN_ARMS]
+    if not content then
+        return
+    end
+
+    for _, lootGroup in ipairs(content.loot) do
+        local krakenClub
+        local filler
+
+        for _, entry in pairs(lootGroup) do
+            if type(entry) == 'table' then
+                if entry.itemId == xi.item.KRAKEN_CLUB then
+                    krakenClub = entry
+                elseif entry.itemId == xi.item.NONE then
+                    filler = entry
+                end
+            end
+        end
+
+        if krakenClub and filler then
+            krakenClub.weight = 10
+            filler.weight     = 9990
+        end
+    end
+end)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Due to various factors impacting the drop rates on LSB, such as login rewards in modern retail making King pop items more plentiful, and level of effort to prove out various drop rates to a more accurate degree, we have made various drop list adjustments in the player's favor:
   - NQ Kings now drop their HQ counterpart's pop item at one increased TH tier (RARE to UNCOMMON)
   - Fafnir Ridill drop rate increased one TH tier (VRARE to RARE)
   - King Vinegaroon Ace's Helm drop rate increased one TH tier (COMMON to VCOMMON)
   - Up In Arms BCNM Kraken Club drop rate increased from 1/10,000 to 10/10,000
- Updates init.txt to include a new Phoenix specific yaml module path

## Steps to test these changes

- Load modules, see that monsters have increased drop rates
