### PR TITLE
[Phoenix] Guild Shop Persistence Module

### DIFF
--- a/modules/phoenix/cpp/guild_shop_persistence.cpp
+++ b/modules/phoenix/cpp/guild_shop_persistence.cpp
@@ -1,0 +1,270 @@
+/************************************************************************
+ * Guild Shop Persistence Module
+ *
+ * The Lua guild shop system keeps every shop's stock and the prices it
+ * locked for the day in the in-memory table xi.guildShops.state, so every
+ * restart resets shops to their configured starting stock. This module
+ * saves that table to guild_shop_state so shops pick up where they left off.
+ *
+ * The table is loaded back once per boot, on the first time server tick
+ * after OnInit. That has to happen after luautils::OnServerStart, because
+ * that is when era_guild_shops.lua patches the shop config.
+ *
+ * A shop whose saved rows still cover every item in its config comes back
+ * exactly as it was, locked prices included. A shop whose config changed
+ * while the server was down gets its stock back with lastRoll = -1. The
+ * first roll then keeps that stock, skips the restock and recomputes the
+ * prices. Saved rows for items no longer in a shop's config are deleted.
+ * If the load fails the module disarms itself for the rest of the uptime
+ * instead of overwriting a snapshot it could not read.
+ *
+ * The Lua helper in modules/phoenix/lua/custom/guild_shop_persistence.lua
+ * keeps a copy of what was last saved and returns only the rows that
+ * changed, so each tick makes one call into Lua. Only stock moves during
+ * the day, so a shop's daily roll is the only write with many rows. The
+ * changed rows are written in one transaction on the tick, the same way
+ * PersistVolatileServerVars writes. A failed write keeps its rows and tries
+ * again next tick. A crash loses at most one tick of changes, and the next
+ * daily roll rewrites the whole shop anyway.
+ *
+ * Turned on by the main.GUILD_SHOP_PERSISTENCE setting, off by default.
+ * Turning it on with a settings reload does nothing until the next restart,
+ * because writing without loading first would overwrite the snapshot.
+ *
+ * Delete rows from guild_shop_state while the server is down to reset a shop.
+ ************************************************************************/
+
+#include "common/database.h"
+#include "common/logging.h"
+#include "common/settings.h"
+#include "map/utils/moduleutils.h"
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+struct ShopRow
+{
+    std::string shop;
+    uint16      itemId    = 0;
+    uint16      stock     = 0;
+    uint32      buyPrice  = 0;
+    uint32      sellPrice = 0;
+    uint8       offered   = 0;
+    uint32      lastRoll  = 0;
+};
+
+enum class State : uint8
+{
+    Off,
+    AwaitingRestore,
+    Running,
+    Disarmed,
+};
+
+} // namespace
+
+class GuildShopPersistenceModule : public CPPModule
+{
+public:
+    void OnInit() override
+    {
+        TracyZoneScoped;
+
+        if (settings::get<bool>("main.GUILD_SHOP_PERSISTENCE"))
+        {
+            state_ = State::AwaitingRestore;
+            ShowInfo("Guild shop persistence enabled");
+        }
+    }
+
+    void OnTimeServerTick() override
+    {
+        switch (state_)
+        {
+            case State::AwaitingRestore:
+                restore();
+                break;
+            case State::Running:
+                persist();
+                break;
+            case State::Off:
+            case State::Disarmed:
+                break;
+        }
+    }
+
+private:
+    void disarm(const std::string& why)
+    {
+        state_ = State::Disarmed;
+        ShowErrorFmt("Guild shop persistence disarmed: {}", why);
+    }
+
+    void restore()
+    {
+        const sol::optional<sol::table> helper = lua["xi"]["guildShops"]["persistence"];
+        if (!helper)
+        {
+            disarm("helper not loaded; is modules/phoenix/lua enabled in init.txt?");
+            return;
+        }
+
+        // Putting a nil straight into a sol::protected_function throws with the
+        // sol safety checks on, so read them as optionals first.
+        const auto restoreFn = helper->get<sol::optional<sol::protected_function>>("restore");
+        const auto collectFn = helper->get<sol::optional<sol::protected_function>>("collect");
+        if (!restoreFn || !collectFn)
+        {
+            disarm("helper is missing restore/collect");
+            return;
+        }
+
+        restoreFn_ = *restoreFn;
+        collectFn_ = *collectFn;
+
+        const auto rset = db::preparedStmt("SELECT shop, itemid, stock, buy_price, sell_price, offered, last_roll FROM guild_shop_state");
+        if (!rset)
+        {
+            // Writing from here on would overwrite the snapshot we could not read.
+            disarm("could not read guild_shop_state");
+            return;
+        }
+
+        auto        rows     = lua.create_table();
+        std::size_t rowCount = 0;
+        while (rset->next())
+        {
+            auto row         = lua.create_table();
+            row["shop"]      = rset->get<std::string>("shop");
+            row["itemId"]    = rset->get<uint16>("itemid");
+            row["stock"]     = rset->get<uint16>("stock");
+            row["buyPrice"]  = rset->get<uint32>("buy_price");
+            row["sellPrice"] = rset->get<uint32>("sell_price");
+            row["offered"]   = rset->get<uint8>("offered");
+            row["lastRoll"]  = rset->get<uint32>("last_roll");
+
+            rows[++rowCount] = row;
+        }
+
+        const auto restoreResult = restoreFn_(rows);
+        if (!restoreResult.valid())
+        {
+            const sol::error err = restoreResult;
+            disarm(fmt::format("restore failed: {}", err.what()));
+            return;
+        }
+
+        const sol::table summary  = restoreResult;
+        const sol::table deletes  = summary["deletes"];
+        const auto       restored = summary.get_or("restored", 0);
+        const auto       reRolled = summary.get_or("reRolled", 0);
+
+        std::size_t pruned = 0;
+        for (const auto& [key, value] : deletes)
+        {
+            const auto entry  = value.as<sol::table>();
+            const auto shop   = entry.get<std::string>("shop");
+            const auto itemId = entry.get<uint16>("itemId");
+
+            if (db::preparedStmt("DELETE FROM guild_shop_state WHERE shop = ? AND itemid = ?", shop, itemId))
+            {
+                ++pruned;
+            }
+            else
+            {
+                // Restore finds the same stale rows again next boot.
+                ShowErrorFmt("Guild shop persistence: failed to prune stale row {}/{}", shop, itemId);
+            }
+        }
+
+        ShowInfoFmt("Guild shop persistence: {} rows read, {} shops restored, {} set to re-roll, {} stale rows pruned", rowCount, restored, reRolled, pruned);
+
+        state_ = State::Running;
+    }
+
+    void persist()
+    {
+        if (!collectDeltas() || pending_.empty())
+        {
+            return;
+        }
+
+        // A failed batch stays in pending_ ahead of the next tick's rows, so
+        // writes land in the order the changes happened.
+        if (writeBatch(pending_))
+        {
+            pending_.clear();
+        }
+    }
+
+    auto collectDeltas() -> bool
+    {
+        const auto collectResult = collectFn_();
+        if (!collectResult.valid())
+        {
+            const sol::error err = collectResult;
+            disarm(fmt::format("collect failed: {}", err.what()));
+            return false;
+        }
+
+        const sol::table deltas = collectResult;
+        for (const auto& [key, value] : deltas)
+        {
+            const auto entry = value.as<sol::table>();
+
+            pending_.emplace_back(ShopRow{
+                .shop      = entry.get<std::string>("shop"),
+                .itemId    = entry.get<uint16>("itemId"),
+                .stock     = entry.get<uint16>("stock"),
+                .buyPrice  = entry.get<uint32>("buyPrice"),
+                .sellPrice = entry.get<uint32>("sellPrice"),
+                .offered   = entry.get<uint8>("offered"),
+                .lastRoll  = entry.get<uint32>("lastRoll"),
+            });
+        }
+
+        return true;
+    }
+
+    auto writeBatch(const std::vector<ShopRow>& batch) -> bool
+    {
+        const auto ok = db::transaction([&batch]()
+                                        {
+                                            for (const auto& row : batch)
+                                            {
+                                                if (!db::preparedStmt("INSERT INTO guild_shop_state SET shop = ?, itemid = ?, stock = ?, buy_price = ?, sell_price = ?, offered = ?, last_roll = ? "
+                                                                      "ON DUPLICATE KEY UPDATE stock = VALUES(stock), buy_price = VALUES(buy_price), sell_price = VALUES(sell_price), offered = VALUES(offered), last_roll = VALUES(last_roll)",
+                                                                      row.shop,
+                                                                      row.itemId,
+                                                                      row.stock,
+                                                                      row.buyPrice,
+                                                                      row.sellPrice,
+                                                                      row.offered,
+                                                                      row.lastRoll))
+                                                {
+                                                    throw std::runtime_error("guild_shop_state upsert failed");
+                                                }
+                                            }
+                                        });
+
+        if (!ok)
+        {
+            ShowErrorFmt("Guild shop persistence: failed to write {} rows, retrying next tick", batch.size());
+        }
+
+        return ok;
+    }
+
+    State state_ = State::Off;
+
+    sol::protected_function restoreFn_;
+    sol::protected_function collectFn_;
+
+    std::vector<ShopRow> pending_;
+};
+
+REGISTER_CPP_MODULE(GuildShopPersistenceModule);

--- a/modules/phoenix/lua/custom/guild_shop_persistence.lua
+++ b/modules/phoenix/lua/custom/guild_shop_persistence.lua
@@ -1,0 +1,136 @@
+-----------------------------------
+-- Guild Shop Persistence
+-- Keeps a copy of what was last saved and finds what changed, for the guild_shop_persistence C++ module.
+-- Registers nothing. The module fetches xi.guildShops.persistence on its first tick.
+-----------------------------------
+require('scripts/globals/guild_shops')
+-----------------------------------
+local helper = {}
+
+-- What was last saved for each shop. [shop] = { lastRoll = day, items = { [itemId] = stock } }
+local shadow = {}
+
+-- Put saved rows back into xi.guildShops.state and fill the shadow copy.
+-- Each row is { shop, itemId, stock, buyPrice, sellPrice, offered, lastRoll }.
+-- Returns the rows to delete ({ shop, itemId }) and how many shops were handled each way.
+helper.restore = function(rows)
+    local today  = VanadielUniqueDay()
+    local byShop = {}
+    for _, row in ipairs(rows) do
+        local saved = byShop[row.shop]
+        if not saved then
+            saved = {}
+            byShop[row.shop] = saved
+        end
+
+        saved[row.itemId] = row
+    end
+
+    local deletes  = {}
+    local restored = 0
+    local reRolled = 0
+    for shopName, saved in pairs(byShop) do
+        local shop = xi.data.guildShops[shopName]
+
+        -- A shop with no config right now (module off, or it became an alias) keeps its
+        -- rows in case it comes back. A shop a player already opened keeps its fresh roll.
+        if shop and shop.stock and not xi.guildShops.state[shopName] then
+            local state       = { lastRoll = -1, items = {} }
+            local shadowItems = {}
+            local configIds   = {}
+
+            -- The saved rows are only used as they are when every configured item has one.
+            -- An item with no row but today's lastRoll would crash the shop handlers.
+            local lastRoll = -1
+            local covered  = true
+            for _, cfg in ipairs(shop.stock) do
+                configIds[cfg.id] = true
+
+                local row = saved[cfg.id]
+                if row then
+                    lastRoll = math.max(lastRoll, row.lastRoll)
+                    state.items[cfg.id] =
+                    {
+                        stock     = row.stock,
+                        buyPrice  = row.buyPrice,
+                        sellPrice = row.sellPrice,
+                        offered   = row.offered ~= 0,
+                    }
+
+                    shadowItems[cfg.id] = row.stock
+                else
+                    covered = false
+                end
+            end
+
+            -- A saved day in the future means the host clock went backwards.
+            -- rollShopDay would restock with negative days, so re-roll instead.
+            if lastRoll > today then
+                covered = false
+            end
+
+            -- A shop with rows missing only gets its stock back. lastRoll = -1 makes
+            -- rollShopDay recompute the prices and keep that stock.
+            if covered then
+                state.lastRoll = lastRoll
+                restored = restored + 1
+            else
+                reRolled = reRolled + 1
+            end
+
+            xi.guildShops.state[shopName] = state
+            shadow[shopName] = { lastRoll = state.lastRoll, items = shadowItems }
+
+            -- rollShopDay never rewrites rows for items that left the stock list,
+            -- so delete them.
+            for itemId in pairs(saved) do
+                if not configIds[itemId] then
+                    deletes[#deletes + 1] = { shop = shopName, itemId = itemId }
+                end
+            end
+        end
+    end
+
+    return { deletes = deletes, restored = restored, reRolled = reRolled }
+end
+
+-- Collect the rows that changed since the last call and update the shadow copy.
+-- Shops that have not rolled yet (lastRoll < 0) are never saved. Prices and the
+-- offered flag only change at a roll, so a lastRoll change writes the whole shop.
+-- Otherwise only stock is compared.
+helper.collect = function()
+    local deltas = {}
+    for shopName, state in pairs(xi.guildShops.state) do
+        if state.lastRoll >= 0 then
+            local shadowShop = shadow[shopName]
+            if not shadowShop then
+                shadowShop = { lastRoll = -1, items = {} }
+                shadow[shopName] = shadowShop
+            end
+
+            local rolled = state.lastRoll ~= shadowShop.lastRoll
+            for itemId, item in pairs(state.items) do
+                if rolled or shadowShop.items[itemId] ~= item.stock then
+                    deltas[#deltas + 1] =
+                    {
+                        shop      = shopName,
+                        itemId    = itemId,
+                        stock     = item.stock,
+                        buyPrice  = item.buyPrice,
+                        sellPrice = item.sellPrice,
+                        offered   = item.offered and 1 or 0,
+                        lastRoll  = state.lastRoll,
+                    }
+
+                    shadowShop.items[itemId] = item.stock
+                end
+            end
+
+            shadowShop.lastRoll = state.lastRoll
+        end
+    end
+
+    return deltas
+end
+
+xi.guildShops.persistence = helper

--- a/modules/phoenix/sql/guild_shop_state.sql
+++ b/modules/phoenix/sql/guild_shop_state.sql
@@ -1,0 +1,25 @@
+--
+-- Guild Shop Persistence Module
+--
+-- One row per shop item, written by the guild_shop_persistence C++ module so
+-- the Lua guild shop system (scripts/globals/guild_shops.lua) keeps its stock
+-- and day-locked prices across restarts.
+--
+-- `shop` is the canonical shop NPC name.
+-- `last_roll` is the Vana'diel day the shop's prices were locked.
+--
+-- Note: This table preserves existing data during database updates.
+--       The table structure will only be created if it doesn't exist.
+--       A schema change therefore needs a tools/migrations entry.
+--
+
+CREATE TABLE IF NOT EXISTS `guild_shop_state` (
+  `shop` varchar(32) NOT NULL,
+  `itemid` smallint(5) unsigned NOT NULL,
+  `stock` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `buy_price` int(10) unsigned NOT NULL DEFAULT 0,
+  `sell_price` int(10) unsigned NOT NULL DEFAULT 0,
+  `offered` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `last_roll` int(10) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`shop`,`itemid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/scripts/tests/modules/guild_shop_persistence.lua
+++ b/scripts/tests/modules/guild_shop_persistence.lua
@@ -1,0 +1,170 @@
+-----------------------------------
+-- Verifies the 'guild_shop_persistence' module (listed in modules/init.txt)
+-- puts saved rows back the way each case needs, and reports only the rows
+-- that changed since the last save.
+--
+-- See: modules/phoenix/lua/custom/guild_shop_persistence.lua
+-----------------------------------
+describe('Module: guild_shop_persistence', function()
+    ---@type CClientEntityPair
+    local player
+    local persistence
+
+    local shopName = 'Kamilah'
+    local probe    = xi.item.CHUNK_OF_TIN_ORE
+
+    local function configItems()
+        return xi.data.guildShops[shopName].stock
+    end
+
+    local function cfgOf(itemId)
+        for _, cfg in ipairs(configItems()) do
+            if cfg.id == itemId then
+                return cfg
+            end
+        end
+    end
+
+    -- A saved row for every configured item, with prices no roll would produce.
+    local function savedRows(lastRoll)
+        local rows = {}
+        for i, cfg in ipairs(configItems()) do
+            rows[#rows + 1] =
+            {
+                shop      = shopName,
+                itemId    = cfg.id,
+                stock     = cfg.initial,
+                buyPrice  = 100000 + i,
+                sellPrice = 50000 + i,
+                offered   = 1,
+                lastRoll  = lastRoll,
+            }
+        end
+
+        return rows
+    end
+
+    local function rowFor(rows, itemId)
+        for i, row in ipairs(rows) do
+            if row.itemId == itemId then
+                return row, i
+            end
+        end
+    end
+
+    -- Other suites leave their own shops in state, so only count this shop's rows.
+    local function changedRows(deltas)
+        local mine = {}
+        for _, delta in ipairs(deltas) do
+            if delta.shop == shopName then
+                mine[#mine + 1] = delta
+            end
+        end
+
+        return mine
+    end
+
+    local function open()
+        xi.test.world:setVanaTime(8, 0)
+        player.entities:gotoAndTrigger(shopName)
+    end
+
+    before_each(function()
+        persistence = xi.guildShops.persistence
+        assert(persistence, 'the guild_shop_persistence module is not loaded, check modules/init.txt')
+
+        player = xi.test.world:spawnPlayer({ zone = xi.zone.MHAURA })
+        xi.guildShops.state[shopName] = nil
+    end)
+
+    after_each(function()
+        xi.guildShops.state[shopName] = nil
+    end)
+
+    it('puts a full snapshot back with its prices and lastRoll intact', function()
+        local today  = VanadielUniqueDay()
+        local result = persistence.restore(savedRows(today))
+        local state  = xi.guildShops.state[shopName]
+
+        assert(result.restored == 1, 'shop not counted as restored')
+        assert(result.reRolled == 0, 'full snapshot was set to re-roll')
+        assert(state.lastRoll == today, 'lastRoll not restored')
+
+        local saved = rowFor(savedRows(today), probe)
+        assert(state.items[probe].buyPrice == saved.buyPrice, 'buy price not restored')
+        assert(state.items[probe].sellPrice == saved.sellPrice, 'sell price not restored')
+        assert(state.items[probe].offered == true, 'offered not restored as a boolean')
+    end)
+
+    it('re-rolls a shop that gained a config item, keeping stock without restocking', function()
+        local rows = savedRows(VanadielUniqueDay())
+
+        -- Drop another item's saved row so the snapshot no longer covers every item.
+        local missing = configItems()[1].id == probe and configItems()[2] or configItems()[1]
+        local _, index = rowFor(rows, missing.id)
+        table.remove(rows, index)
+
+        -- Leave the probe below targetStock so a normal roll would restock it.
+        local cfg   = cfgOf(probe)
+        local stock = cfg.targetStock - cfg.restockRate * 2
+        local saved = rowFor(rows, probe)
+        saved.stock = stock
+
+        local result = persistence.restore(rows)
+        assert(result.reRolled == 1, 'shop with a missing row not set to re-roll')
+        assert(xi.guildShops.state[shopName].lastRoll == -1, 'lastRoll not cleared')
+
+        open()
+
+        local state = xi.guildShops.state[shopName]
+        assert(state.lastRoll == VanadielUniqueDay(), 'first open did not roll')
+        assert(state.items[probe].stock == stock, 'first roll restocked the saved stock')
+        assert(state.items[probe].buyPrice ~= saved.buyPrice, 'first roll kept the saved price')
+        assert(state.items[missing.id].stock == missing.initial, 'new config item not given its starting stock')
+    end)
+
+    it('re-rolls a snapshot saved on a future day', function()
+        local result = persistence.restore(savedRows(VanadielUniqueDay() + 5))
+
+        assert(result.reRolled == 1, 'future snapshot not set to re-roll')
+        assert(xi.guildShops.state[shopName].lastRoll == -1, 'future lastRoll kept')
+    end)
+
+    it('reports saved rows for items no longer in the config', function()
+        local rows = savedRows(VanadielUniqueDay())
+        rows[#rows + 1] =
+        {
+            shop      = shopName,
+            itemId    = 60000,
+            stock     = 5,
+            buyPrice  = 1,
+            sellPrice = 1,
+            offered   = 1,
+            lastRoll  = VanadielUniqueDay(),
+        }
+
+        local result = persistence.restore(rows)
+
+        assert(result.restored == 1, 'the extra row stopped the shop restoring')
+        assert(#result.deletes == 1, 'stale row not reported')
+        assert(result.deletes[1].shop == shopName and result.deletes[1].itemId == 60000, 'wrong stale row reported')
+    end)
+
+    it('reports only stock changes until a roll, which returns every row', function()
+        persistence.restore(savedRows(VanadielUniqueDay()))
+        persistence.collect() -- the first call picks up shops other suites left behind
+
+        assert(#changedRows(persistence.collect()) == 0, 'restoring on its own reported changes')
+
+        local state = xi.guildShops.state[shopName]
+        state.items[probe].stock = state.items[probe].stock - 1
+
+        local changed = changedRows(persistence.collect())
+        assert(#changed == 1, 'a stock change did not report exactly one row')
+        assert(changed[1].itemId == probe and changed[1].stock == state.items[probe].stock, 'wrong row reported')
+        assert(#changedRows(persistence.collect()) == 0, 'the same change was reported twice')
+
+        state.lastRoll = state.lastRoll + 1
+        assert(#changedRows(persistence.collect()) == #configItems(), 'a roll did not report every row')
+    end)
+end)

--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -331,6 +331,7 @@ xi.settings.main =
     PERSIST_SEAL_TIMERS          = false, -- Persist seal (Beastmen/Kindred) recast timers across zone changes and logout.
     GUILD_SHOP_HOLIDAYS          = false, -- true/false. Close each guild shop on its weekly holiday.
     ENABLE_COSMETIC_WARDROBE     = false, -- true/false. Mog Wardrobe 8 opens at 80 slots and only accepts the cosmetic item list. Requires the cosmetic_wardrobe modules.
+    GUILD_SHOP_PERSISTENCE       = false, -- true/false. Guild shop stock and prices survive server restarts. Requires the guild_shop_persistence module.
 
     -- SYSTEM
     DISABLE_INACTIVITY_WATCHDOG = false, -- true/false. If this is enabled, the watchdog which detects if the main loop isn't being ticked will no longer be able to kill the process.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Guild vendors reset their stock and prices every time the server restarts or crashes because the shop state only lives in memory. This module saves that state to a table and loads it back on startup, so shops keep what they had before the restart.

Off by default. Turn it on with the GUILD_SHOP_PERSISTENCE setting.

## Notes

- Same-day restart: stock and prices come back exactly.
- Restart across a Vana'diel midnight: the shop restocks like normal on the next visit.
- If a shop's item list changed while the server was down, it re-rolls its prices from the saved stock instead of erroring.
- New module under modules/phoenix, no core files touched. The C++ side reads and writes the table; the Lua helper next to it works out which rows changed, so each tick makes one call into Lua and writes only what moved.
- Writes run on the tick in one transaction, the same way the volatile server vars are saved. A failed write is retried next tick.
- Comes with a test under scripts/tests/systems/guild_shops/persistence.lua covering the restore rules and the change tracking.

Off by default. Turn it on with the GUILD_SHOP_PERSISTENCE setting. Some notes:

- Same-day restart: stock and prices come back exactly.
- Restart across a Vana'diel midnight: the shop restocks like normal on the next visit.

## Steps to test these changes

Buy from shops. Restart. See it's all saved. To reset a shop, delete it's rows while the server is down.

Build needs a fresh cmake configure before compiling, since init.txt is read at configure time. Then dbtool update (or import guild_shop_state.sql by hand) and turn the setting on.