### PR TITLE
[lua] Implement CoP Area Experience Points Restrictions

### DIFF
--- a/modules/phoenix/lua/custom/pet_exp_penalty.lua
+++ b/modules/phoenix/lua/custom/pet_exp_penalty.lua
@@ -1,16 +1,74 @@
 -----------------------------------
--- Phoenix Pet EXP Penalty Module
---
--- Parties of 3 or less will not be affected by this module.
+-- Phoenix Level-Restricted EXP and Pet EXP Penalty Module
+-- Restores the experience points penalty applied in level-restricted zones added in 2004.
+-- Parties of 3 or less will not be affected by the pet EXP penalty.
 -- When 4 players are in the party, pets will only give 30% of their normal EXP (70% penalty).
 -- When 5 players are in the party, pets will only give 20% of their normal EXP (80% penalty).
 -- When 6 or more players are in the party/alliance, pets will only give 10% of their normal EXP (90% penalty).
 -----------------------------------
 require('modules/module_utils')
 
-local m = Module:new('pet_exp_penalty')
+local m = Module:new('pet_exp_penalty', xi.pre(xi.expansion.ABYSSEA))
 
--- Percent of exp removed per party size. Sizes past the table use the last entry.
+-- Zones where the level capped experience penalty applies.
+local cappedZones =
+{
+    [xi.zone.PSOXJA]             = true,
+    [xi.zone.PROMYVION_HOLLA]    = true,
+    [xi.zone.PROMYVION_DEM]      = true,
+    [xi.zone.PROMYVION_MEA]      = true,
+    [xi.zone.PROMYVION_VAHZL]    = true,
+    [xi.zone.PHOMIUNA_AQUEDUCTS] = true,
+    [xi.zone.SACRARIUM]          = true,
+    [xi.zone.RIVERNE_SITE_A01]   = true,
+    [xi.zone.RIVERNE_SITE_B01]   = true,
+}
+
+local function getExperienceToLevel(level)
+    if level <= 7 then
+        return 250 * (level + 1)
+    elseif level <= 22 then
+        return 200 * level + 600
+    end
+
+    return 100 * level + 2800
+end
+
+local function getExperienceGrade(data)
+    if
+        data.highestMemberLevel > 50 or
+        data.highestMemberLevel > data.memberLevel + 7
+    then
+        return data.baseExp * data.memberLevel / data.highestMemberLevel
+    end
+
+    return data.baseExp * data.memberTNL / data.highestMemberTNL
+end
+
+local function getActualPartyLevel(member, mob, data)
+    local actualLevel   = member:getJobLevel(member:getMainJob())
+    local highestActual = math.min(math.max(actualLevel, data.highestMemberLevel), 99)
+
+    local mobLevel        = mob:getMainLvl() + mob:getMod(xi.mod.EXP_LVL_MOD)
+    local baseTableRow    = xi.data.experiencePoints.baseTable[utils.clamp(mobLevel - highestActual, -44, 15)]
+    local actualPartyData = {}
+    for key, value in pairs(data) do
+        actualPartyData[key] = value
+    end
+
+    actualPartyData.baseExp            = baseTableRow[math.floor((highestActual - 1) / 5) + 1]
+    actualPartyData.memberLevel        = actualLevel
+    actualPartyData.highestMemberLevel = highestActual
+
+    if highestActual <= 50 and highestActual <= actualLevel + 7 then
+        actualPartyData.memberTNL        = getExperienceToLevel(actualLevel)
+        actualPartyData.highestMemberTNL = getExperienceToLevel(highestActual)
+    end
+
+    return actualPartyData
+end
+
+-- EXP removed from monster-owned pets, by party size.
 local penaltyBySize =
 {
     [4] = 70,
@@ -19,14 +77,32 @@ local penaltyBySize =
 }
 
 m:addOverride('xi.experiencePoints.calculate', function(member, mob, data)
-    local result = super(member, mob, data)
+    local calculationData     = data
+    local hasLevelRestriction = member:getStatusEffect(xi.effect.LEVEL_RESTRICTION)
+    if
+        cappedZones[member:getZoneID()] and
+        hasLevelRestriction and
+        member:getMainLvl() < member:getJobLevel(member:getMainJob())
+    then
+        local actualPartyData = getActualPartyLevel(member, mob, data)
+        if getExperienceGrade(data) * 0.5 <= getExperienceGrade(actualPartyData) then
+            calculationData = actualPartyData
+        else
+            calculationData = {}
+            for key, value in pairs(data) do
+                calculationData[key] = value
+            end
+
+            calculationData.baseExp = data.baseExp * 0.5
+        end
+    end
+
+    local result = super(member, mob, calculationData)
 
     if not result or data.partySize < 4 then
         return result
     end
 
-    -- Only pets owned by another monster. Charmed pets and player jug pets have
-    -- a player master and keep full value.
     local master = mob:getMaster()
     if not master or not master:isMob() then
         return result

--- a/modules/phoenix/tests/level_restricted_exp.lua
+++ b/modules/phoenix/tests/level_restricted_exp.lua
@@ -1,0 +1,413 @@
+-----------------------------------
+-- Exercises the real EXP calculation and module overrides in an isolated Lua
+-- environment, without changing the running world's modules or EXP tables.
+-----------------------------------
+describe('Level-restricted experience points', function()
+    local function constant(value)
+        return function()
+            return value
+        end
+    end
+
+    local function fixture(eraEnabled, useToau)
+        local actual = { baseExp = 0, memberLevel = 75, highestMemberLevel = 75 }
+        local testXi =
+        {
+            effect        = xi.effect,
+            zone          = xi.zone,
+            region        = xi.region,
+            mod           = xi.mod,
+            mobMod        = xi.mobMod,
+            mobDifficulty = xi.mobDifficulty,
+            ki            = xi.ki,
+            data          = { experiencePoints = { baseTable = {} } },
+            settings      = { main = { RESTRICT_CONTENT = 1, ENABLE_ABYSSEA = eraEnabled and 0 or 1 } },
+        }
+
+        for difference = -44, 15 do
+            testXi.data.experiencePoints.baseTable[difference] = setmetatable({},
+                {
+                    __index = function()
+                        return actual.baseExp
+                    end,
+                })
+        end
+
+        local env = setmetatable({ xi = testXi }, { __index = _G })
+        -- module_utils is loaded into this environment below.
+        env.require = function()
+        end
+
+        for _, path in ipairs(
+            {
+                'modules/module_utils.lua',
+                'scripts/globals/experience_points.lua',
+                'modules/phoenix/lua/custom/pet_exp_penalty.lua',
+            })
+        do
+            setfenv(assert(loadfile(path)), env)()
+        end
+
+        local coreCalculate = testXi.experiencePoints.calculate
+        actual.calls = 0
+        testXi.experiencePoints.calculate = function(member, mob, data)
+            actual.calls = actual.calls + 1
+            actual.receivedData = data
+            return coreCalculate(member, mob, data)
+        end
+
+        for _, module in ipairs(testXi.module.registry) do
+            if module.enabled then
+                for _, override in ipairs(module.overrides) do
+                    local name = override.name:match('%.([^%.]+)$')
+                    env.applyOverride(testXi.experiencePoints, name, override.func)
+                end
+            end
+        end
+
+        testXi.experiencePoints.perMonsterCaps =
+        {
+            { maxLevel = 50,  cap = 200 },
+            { maxLevel = 60,  cap = 250 },
+            { maxLevel = 255, cap = 300 },
+        }
+
+        if useToau then
+            testXi.settings.main.ENABLE_WOTG = 0
+            testXi.server = { onServerStart = setfenv(constant(nil), env) }
+            env.ReloadExperienceData = function()
+            end
+
+            env.LoadExpDifficultyCurves = function()
+            end
+
+            setfenv(assert(loadfile('modules/era/lua/globals/toau_experience_points.lua')), env)()
+            local era = testXi.module.registry[#testXi.module.registry]
+            assert(era.enabled)
+            env.applyOverride(testXi.server, 'onServerStart', era.overrides[1].func)
+            testXi.server.onServerStart()
+        end
+
+        local member =
+        {
+            zoneId = xi.zone.PROMYVION_HOLLA,
+            effects = {},
+            bonus = 0,
+            getMainLvl = constant(30),
+            getMainJob = constant(1),
+            getJobLevel = function()
+                return actual.memberLevel
+            end,
+
+            isPC = constant(true),
+            checkDistance = constant(0),
+            getAlliance = function(self)
+                local highest = setmetatable(
+                    { getJobLevel = constant(actual.highestMemberLevel) }, { __index = self })
+                return { self, highest }
+            end,
+
+            hasKeyItem = constant(false),
+            getZoneID = function(self)
+                return self.zoneId
+            end,
+
+            getStatusEffect = function(self, effect)
+                return self.effects[effect]
+            end,
+
+            hasStatusEffect = function(self, effect)
+                return self.effects[effect] ~= nil
+            end,
+
+            delStatusEffect = function(self, effect)
+                self.effects[effect] = nil
+            end,
+
+            getMod = function(self)
+                return self.bonus
+            end,
+        }
+        member.effects[xi.effect.LEVEL_RESTRICTION] = { getSubPower = constant(0) }
+
+        local mob =
+        {
+            bonus = 0,
+            getMobMod = function(self)
+                return self.bonus
+            end,
+
+            getMod = constant(0),
+            getMainLvl = constant(40),
+            getZoneID = function()
+                return xi.zone.PROMYVION_HOLLA
+            end,
+
+            getMaster = function(self)
+                return self.master
+            end,
+        }
+
+        local data =
+        {
+            baseExp                  = 200,
+            memberLevel              = 30,
+            highestMemberLevel       = 30,
+            memberTNL                = 5800,
+            highestMemberTNL         = 5800,
+            partySize                = 1,
+            regionId                 = xi.region.TAVNAZIA,
+            mobDifficulty            = xi.mobDifficulty.EVEN_MATCH,
+            chainNumber              = 1,
+            chainActive              = false,
+        }
+
+        return testXi.experiencePoints.calculate, member, mob, data, actual, testXi
+    end
+
+    it('halves the input and leaves the monster cap to core', function()
+        local calculate, member, mob, data = fixture(true)
+        data.baseExp = 600
+        assert(calculate(member, mob, data).exp == 200)
+        assert(data.baseExp == 600 and data.memberLevel == 30)
+    end)
+
+    it('delegates the winning actual-level input to core', function()
+        local calculate, member, mob, data, actual = fixture(true)
+        actual.baseExp = 240
+        assert(calculate(member, mob, data).exp == 240)
+    end)
+
+    it('uses the stock actual-level TNL grade', function()
+        local calculate, member, mob, data, actual = fixture(true)
+        data.baseExp = 100
+        actual.baseExp = 100
+        actual.memberLevel = 40
+        data.highestMemberLevel = 45
+        data.highestMemberTNL = 7300
+        assert(calculate(member, mob, data).exp == 93)
+    end)
+
+    it('retains contribution penalties in the actual-level grade', function()
+        local calculate, member, mob, data, actual = fixture(true)
+        data.baseExp = 100
+        actual.baseExp = 120
+        actual.memberLevel = 40
+        data.highestMemberLevel = 75
+        assert(calculate(member, mob, data).exp == 64)
+    end)
+
+    it('preserves chains at the restricted level and consumes Dedication once', function()
+        local calculate, member, mob, data = fixture(true)
+        local dedication =
+        {
+            cap = 1000,
+            writes = 0,
+            getPower = constant(50),
+            getSubPower = function(self)
+                return self.cap
+            end,
+
+            setSubPower = function(self, value)
+                self.cap = value
+                self.writes = self.writes + 1
+            end,
+        }
+        member.effects[xi.effect.DEDICATION] = dedication
+        data.chainActive = true
+        local result = calculate(member, mob, data)
+        assert(result.exp == 180 and result.chainActive and result.chainWindow > 0)
+        assert(dedication.cap == 940 and dedication.writes == 1)
+    end)
+
+    it('does not chain a decent challenge', function()
+        local calculate, member, mob, data = fixture(true)
+        data.mobDifficulty = xi.mobDifficulty.DECENT_CHALLENGE
+        data.chainActive = true
+        local result = calculate(member, mob, data)
+        assert(result.exp == 100 and not result.chainActive and result.chainWindow == 0)
+    end)
+
+    it('keeps fractional EXP until final rounding', function()
+        local calculate, member, mob, data = fixture(true)
+        data.baseExp = 101
+        member.bonus = 10
+        assert(calculate(member, mob, data).exp == 55)
+    end)
+
+    it('preserves monster bonuses before the cap', function()
+        local calculate, member, mob, data = fixture(true)
+        data.baseExp = 150
+        mob.bonus = 100
+        assert(calculate(member, mob, data).exp == 150)
+    end)
+
+    it('applies CoP restrictions even when Level Sync is also present', function()
+        local calculate, member, mob, data = fixture(true)
+        member.effects[xi.effect.LEVEL_RESTRICTION] = nil
+        assert(calculate(member, mob, data).exp == 200)
+        member.effects[xi.effect.LEVEL_SYNC] = {}
+        assert(calculate(member, mob, data).exp == 200)
+        member.effects[xi.effect.LEVEL_RESTRICTION] = { getSubPower = constant(0) }
+        assert(calculate(member, mob, data).exp == 100)
+    end)
+
+    it('leaves unaffected levels alone', function()
+        local calculate, member, mob, data, actual = fixture(true)
+        actual.memberLevel = data.memberLevel
+        assert(calculate(member, mob, data).exp == 200)
+    end)
+
+    it('leaves restrictions outside CoP alone and honors the era gate', function()
+        local calculate, member, mob, data = fixture(true)
+        member.zoneId = xi.zone.GM_HOME
+        assert(calculate(member, mob, data).exp == 200)
+        calculate, member, mob, data = fixture(false)
+        assert(calculate(member, mob, data).exp == 200)
+    end)
+
+    it('preserves the custom pet deterrent once for every party size', function()
+        local expected = { 100, 60, 45, 12, 7, 3, 2 }
+        for size = 1, 7 do
+            local calculate, member, mob, data = fixture(true)
+            mob.master = { isMob = constant(true) }
+            data.partySize = size
+            assert(calculate(member, mob, data).exp == expected[size], string.format('party size %d', size))
+        end
+    end)
+
+    it('leaves all EXP handling to core when the module is disabled', function()
+        local calculate, member, mob, data = fixture(false)
+        mob.master = { isMob = constant(true) }
+        data.partySize = 4
+        assert(calculate(member, mob, data).exp == 80)
+    end)
+
+    it('does not penalize wild monsters or player-owned pets', function()
+        local calculate, member, mob, data = fixture(true)
+        data.partySize = 6
+        assert(calculate(member, mob, data).exp == 35)
+        mob.master = { isMob = constant(false) }
+        assert(calculate(member, mob, data).exp == 35)
+    end)
+
+    it('preserves a higher contribution level supplied by core', function()
+        local calculate, member, mob, data, actual = fixture(true)
+        data.baseExp = 100
+        data.highestMemberLevel = 80
+        actual.baseExp = 120
+        actual.memberLevel = 40
+        assert(calculate(member, mob, data).exp == 60)
+    end)
+
+    it('awards the recipient 105 EXP in the ToAU mixed-party example', function()
+        local calculate, member, mob, data, actual, testXi = fixture(true, true)
+        member.getMainLvl        = constant(40)
+        mob.getMainLvl           = constant(45)
+        actual.memberLevel       = 41
+        data.memberLevel         = 40
+        data.highestMemberLevel  = 40
+        data.memberTNL           = 6800
+        data.highestMemberTNL    = 6800
+        data.partySize           = 6
+        data.baseExp             = testXi.data.experiencePoints.baseTable[5][8]
+
+        assert(data.baseExp == 400)
+        assert(calculate(member, mob, data).exp == 105 and actual.calls == 1)
+        assert(actual.receivedData.baseExp == 300 and actual.receivedData.memberLevel == 41)
+
+        actual.highestMemberLevel = 41
+        assert(calculate(member, mob, data).exp == 105)
+
+        actual.memberLevel = 75
+        assert(calculate(member, mob, data).exp == 70)
+
+        actual.memberLevel = 41
+        mob.master = { isMob = constant(true) }
+        assert(calculate(member, mob, data).exp == 10)
+    end)
+
+    it('uses the live base table, level brackets, clamps and EXP_LVL_MOD', function()
+        local calculate, member, mob, data, actual, testXi = fixture(true)
+        data.baseExp = 0
+        actual.memberLevel = 40
+        actual.highestMemberLevel = 40
+        testXi.data.experiencePoints.baseTable[15][8] = 120
+        mob.getMainLvl = constant(80)
+        assert(calculate(member, mob, data).exp == 120)
+        testXi.data.experiencePoints.baseTable[0][8] = 110
+        mob.getMainLvl = constant(39)
+        mob.getMod = constant(1)
+        assert(calculate(member, mob, data).exp == 110)
+        actual.memberLevel = 99
+        actual.highestMemberLevel = 99
+        testXi.data.experiencePoints.baseTable[-44][20] = 10
+        assert(calculate(member, mob, data).exp == 10)
+    end)
+
+    it('matches the stock SQL TNL table through level 50', function()
+        local tnl = {}
+        for line in io.lines('sql/exp_base.sql') do
+            local level, exp = line:match('VALUES %((%d+),(%d+)%)')
+            if level then
+                tnl[tonumber(level) - 1] = tonumber(exp)
+            end
+        end
+
+        for level = 2, 49 do
+            local calculate, member, mob, data, actual = fixture(true)
+            member.getMainLvl = constant(1)
+            data.baseExp = 0
+            data.memberLevel = 1
+            data.highestMemberLevel = level + 1
+            data.highestMemberTNL = tnl[level + 1]
+            actual.memberLevel = level
+            actual.baseExp = 100
+            local expected = math.floor(100 * tnl[level] / tnl[level + 1])
+            assert(calculate(member, mob, data).exp == expected, string.format('TNL at level %d', level))
+        end
+    end)
+
+    it('keeps the existing post-bonus pet penalty and Dedication depletion', function()
+        local calculate, member, mob, data = fixture(true)
+        data.partySize = 4
+        mob.master = { isMob = constant(true) }
+        member.effects[xi.effect.DEDICATION] =
+        {
+            getPower = constant(50),
+            getSubPower = constant(15),
+            setSubPower = function(_, value)
+                assert(value == 0)
+            end,
+        }
+        -- 40 restricted EXP + 15 remaining Dedication, then retain 30%.
+        assert(calculate(member, mob, data).exp == 16)
+        assert(member.effects[xi.effect.DEDICATION] == nil)
+    end)
+
+    it('uses one calculation followed by the pet check for every award path', function()
+        local calculate, member, mob, data, actual = fixture(true)
+        local result = calculate(member, mob, data)
+        assert(result.exp == 100 and actual.calls == 1)
+        assert(actual.receivedData ~= data and actual.receivedData.baseExp == 100)
+        assert(data.baseExp == 200)
+        actual.baseExp = 150
+        result = calculate(member, mob, data)
+        assert(result.exp == 150 and actual.calls == 2)
+        assert(actual.receivedData.memberLevel == 75 and data.memberLevel == 30)
+
+        data.partySize = 4
+        mob.master = { isMob = constant(true) }
+        assert(calculate(member, mob, data).exp == 18 and actual.calls == 3)
+
+        member.effects[xi.effect.LEVEL_SYNC] = {}
+        assert(calculate(member, mob, data).exp == 18 and actual.calls == 4)
+        member.effects = {}
+        assert(calculate(member, mob, data).exp == 24 and actual.calls == 5)
+
+        calculate, member, mob, data, actual = fixture(false)
+        data.partySize = 4
+        mob.master = { isMob = constant(true) }
+        assert(calculate(member, mob, data).exp == 80 and actual.calls == 1)
+    end)
+end)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Adds the zone-based experience points penalty for CoP Level capped zones added in 2004. 

<img width="990" height="476" alt="image" src="https://github.com/user-attachments/assets/2ae185fa-3a36-4aed-bec7-f355df2ce370" />

Essentially the module does just this, calculates the experience points based off the players true level and awards the higher of the two paths. 

Managed to preserve all behavior added with the pet EXP penalty, PR includes 20 tests.

## Steps to test these changes

* Enable the module & the ToAU EXP module, make sure CoP zones are also level capped. Change to a level 75 job in Riverne Site, observe 50% EXP penalty. 
